### PR TITLE
Add running mechanic: Run state, transitions, and input binding

### DIFF
--- a/Core/Entity/Scripts/Player.cs
+++ b/Core/Entity/Scripts/Player.cs
@@ -40,6 +40,7 @@ namespace ethra.V1
         }
 
         public bool AttackPressed { get; set; } = false;
+        public bool RunPressed { get; set; } = false;
 
         public Player(IEntityManager entity, ICombat combat, IInventory inventory, IStateMachine fsm): base (entity, combat, fsm)
         {

--- a/Core/Entity/Scripts/StateMachine/States/Utility/PlayerStateBuilder.cs
+++ b/Core/Entity/Scripts/StateMachine/States/Utility/PlayerStateBuilder.cs
@@ -18,6 +18,8 @@ namespace ethra.V1
 
         private static List<BaseState> PlayerLocomotion(Entity owner, float moveSpeed)
         {
+            float runSpeed = moveSpeed * 1.8f;
+
             BaseState idle = new BaseState
             (
                 "Idle",
@@ -41,12 +43,28 @@ namespace ethra.V1
                 },
                 baseTransitions: new List<IStateTransition>()
             );
+
+            BaseState run = new BaseState
+            (
+                "Run",
+                owner,
+                baseActions: new List<IStateAction>
+                {
+                    new SetAnimationRequestAction("Run"),
+                    new MoveFromInputAction(runSpeed)
+                },
+                baseTransitions: new List<IStateTransition>()
+            );
             
 
             idle.Transitions.Add(new MoveInputNonZeroTransition(walk));
+            idle.Transitions.Add(new RunPressedTransition(run));
             walk.Transitions.Add(new MoveInputZeroTransition(idle));
+            walk.Transitions.Add(new RunPressedTransition(run));
+            run.Transitions.Add(new MoveInputZeroTransition(idle));
+            run.Transitions.Add(new RunReleasedTransition(walk));
 
-            return new List<BaseState> {idle, walk};
+            return new List<BaseState> {idle, walk, run};
         }
 
     }

--- a/Core/Entity/Scripts/StateMachine/Transitions/Locomotion/RunPressedTransition.cs
+++ b/Core/Entity/Scripts/StateMachine/Transitions/Locomotion/RunPressedTransition.cs
@@ -1,0 +1,29 @@
+namespace ethra.V1.Transitions
+{
+    /// <summary>
+    /// Transition when Run input is currently held.
+    /// ONLY WORKS FOR PLAYER.
+    /// </summary>
+    public sealed class RunPressedTransition : IStateTransition
+    {
+        public BaseState Target { get; }
+        private readonly float _deadZone;
+
+        public RunPressedTransition(BaseState target, float deadZone = 0.05f)
+        {
+            Target = target;
+            _deadZone = deadZone;
+        }
+
+        public bool ShouldTransition(Entity owner)
+        {
+            if (owner is Player player)
+            {
+                return player.RunPressed &&
+                       player.MoveInput.LengthSquared() > (_deadZone * _deadZone);
+            }
+
+            return false;
+        }
+    }
+}

--- a/Core/Entity/Scripts/StateMachine/Transitions/Locomotion/RunReleasedTransition.cs
+++ b/Core/Entity/Scripts/StateMachine/Transitions/Locomotion/RunReleasedTransition.cs
@@ -1,0 +1,26 @@
+namespace ethra.V1.Transitions
+{
+    /// <summary>
+    /// Transition when Run input is not currently held.
+    /// ONLY WORKS FOR PLAYER.
+    /// </summary>
+    public sealed class RunReleasedTransition : IStateTransition
+    {
+        public BaseState Target { get; }
+
+        public RunReleasedTransition(BaseState target)
+        {
+            Target = target;
+        }
+
+        public bool ShouldTransition(Entity owner)
+        {
+            if (owner is Player player)
+            {
+                return !player.RunPressed;
+            }
+
+            return false;
+        }
+    }
+}

--- a/Core/Nodes/Entity/PlayerNode.cs
+++ b/Core/Nodes/Entity/PlayerNode.cs
@@ -46,6 +46,7 @@ namespace ethra.V1
 			float dt = (float)delta;
 
 			_player.MoveInput = Input.GetVector("Left", "Right", "Up", "Down");
+			_player.RunPressed = Input.IsActionPressed("Run");
 			_player.Tick(dt);
 
 			Velocity = _player.DesiredVelocity;


### PR DESCRIPTION
### Motivation

- Introduce a running locomotion mode so the player can move faster while holding a Run input.
- Extend the state machine to model Run as a distinct state with proper enter/exit conditions.
- Wire input from the UI layer into the player entity so state transitions can react to the Run control.

### Description

- Added a `RunPressed` boolean to `Player` and set it from `Input.IsActionPressed("Run")` in `PlayerNode` so the entity knows when the run input is held.
- Extended `PlayerStateBuilder` to create a `Run` state with a higher `runSpeed`, added transitions `RunPressedTransition` and `RunReleasedTransition`, and included the `Run` state in the returned state list.
- Implemented `RunPressedTransition` and `RunReleasedTransition` classes to switch between `Walk` and `Run` based on `Player.RunPressed` and the movement deadzone.

### Testing

- No automated tests were executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfcfe93f9083269382a58ea2e2ae80)