### PR TITLE
Add CSV item repo, inventory item types, and pickup handling

### DIFF
--- a/Core/Inventory/Data/items_seed.csv
+++ b/Core/Inventory/Data/items_seed.csv
@@ -1,0 +1,4 @@
+id,name,description,rarity,sell_value,category,subtype,max_stack
+1001,Small Health Potion,Restores a small amount of HP,Common,5,Consumable,Potion,99
+2001,Rusted Sword,An old blade with low durability,Common,10,Weapon,Sword,1
+3001,Copper Ore,Base crafting ore,Common,2,Crafting,Ore,99

--- a/Core/Inventory/Interfaces/IInventory.cs
+++ b/Core/Inventory/Interfaces/IInventory.cs
@@ -7,7 +7,7 @@ namespace ethra.V1
         
         void UseItem(int id);
 
-        void AddItem(int id);
+        bool AddItem(int id);
 
         void DropItem(int id);
 

--- a/Core/Inventory/Scripts/BasicInventoryItem.cs
+++ b/Core/Inventory/Scripts/BasicInventoryItem.cs
@@ -1,0 +1,21 @@
+using System.Collections.Generic;
+
+namespace ethra.V1
+{
+    public class BasicInventoryItem : InventoryItem
+    {
+        public BasicInventoryItem(
+            int id,
+            string name,
+            int value,
+            string description,
+            string rarity,
+            List<ItemEffects> effects = null,
+            string category = "",
+            string subtype = "",
+            int maxStack = 99)
+            : base(id, name, value, description, rarity, effects, category, subtype, maxStack)
+        {
+        }
+    }
+}

--- a/Core/Inventory/Scripts/CraftingItem.cs
+++ b/Core/Inventory/Scripts/CraftingItem.cs
@@ -1,0 +1,28 @@
+using Godot;
+using System.Collections.Generic;
+
+namespace ethra.V1
+{
+    public class CraftingItem : InventoryItem
+    {
+        public string MaterialType => Subtype;
+
+        public CraftingItem(
+            int id,
+            string name,
+            int value,
+            string description,
+            string rarity,
+            string subtype,
+            int maxStack,
+            List<ItemEffects> effects = null)
+            : base(id, name, value, description, rarity, effects, category: "Crafting", subtype: subtype, maxStack: maxStack)
+        {
+        }
+
+        public override void Use()
+        {
+            GD.Print($"Crafting item '{Name}' cannot be used directly.");
+        }
+    }
+}

--- a/Core/Inventory/Scripts/InventoryItem.cs
+++ b/Core/Inventory/Scripts/InventoryItem.cs
@@ -1,39 +1,60 @@
 using System.Collections.Generic;
-using System.Linq;
 using Godot;
 
 namespace ethra.V1
 {
     public abstract class InventoryItem : IInventoryItem, IResolveable
     {
-        private int _id;
-        private string _name;
-        private int _value;
-        private string description;
-        private string _rarity;
-        private List<ItemEffects> _effects;
-        private int _resolveOrder = 15;
-        private Entity _owner;
+        protected int _id;
+        protected string _name;
+        protected int _value;
+        protected string _description;
+        protected string _rarity;
+        protected string _category;
+        protected string _subtype;
+        protected int _maxStack = 99;
+        protected List<ItemEffects> _effects;
+        protected int _resolveOrder = 15;
+        protected Entity _owner;
 
         public int Id => _id;
         public string Name => _name;
         public int Value => _value;
-        public string Description => description;
+        public string Description => _description;
         public string Rarity => _rarity;
+        public string Category => _category;
+        public string Subtype => _subtype;
+        public int MaxStack => _maxStack;
         public List<ItemEffects> Effects => _effects;
         public Entity Owner => _owner;
 
         public int ResolveOrder => _resolveOrder;
 
+        protected InventoryItem()
+        {
+            _effects = new List<ItemEffects>();
+        }
 
+        protected InventoryItem(int id, string name, int value, string description, string rarity, List<ItemEffects> effects = null, string category = "", string subtype = "", int maxStack = 99)
+        {
+            _id = id;
+            _name = name;
+            _value = value;
+            _description = description;
+            _rarity = rarity;
+            _category = category;
+            _subtype = subtype;
+            _maxStack = maxStack > 0 ? maxStack : 99;
+            _effects = effects ?? new List<ItemEffects>();
+        }
 
         public ItemInfo GetInfo()
         {
-            string[] effectList = new string[12];
+            List<string> effectList = new List<string>();
 
-            foreach(ItemEffects effect in Effects)
+            foreach (ItemEffects effect in Effects)
             {
-                effectList.Append(effect.ToString());
+                effectList.Add(effect.ToString());
             }
             return new ItemInfo
             {
@@ -41,7 +62,7 @@ namespace ethra.V1
                 Value = Value.ToString(),
                 Description = Description,
                 Rarity = Rarity,
-                Effects = effectList
+                Effects = effectList.ToArray()
             };
         }
 
@@ -57,7 +78,8 @@ namespace ethra.V1
 
         public virtual void Use()
         {
-            GD.Print($"===Item Used=== : {Name} on {_owner.Name}");
+            string ownerName = _owner != null ? _owner.Name : "None";
+            GD.Print($"===Item Used=== : {Name} on {ownerName}");
         }
     }
 }

--- a/Core/Managers/GameManager.cs
+++ b/Core/Managers/GameManager.cs
@@ -64,12 +64,12 @@ namespace ethra.V1
 	[ExportGroup("Scene folder Path")]
 	[Export] public string SceneFolderLocation;
 
-	[ExportGroup("SQLite Connection Strings")]
+	[ExportGroup("Repository Data Sources")]
 
-	[ExportSubgroup("Dialog Table Connection")]
-	[Export] public string DialogConn;
-	[ExportSubgroup("Item Table Connection")]
-	[Export] public string ItemConn;
+	[ExportSubgroup("Dialog CSV")]
+	[Export] public string DialogCsvPath = string.Empty;
+	[ExportSubgroup("Item CSV")]
+	[Export] public string ItemCsvPath = "res://Core/Inventory/Data/items_seed.csv";
 
 	[ExportGroup("Player Exports")]
 		[ExportSubgroup("StateMachine")]
@@ -207,8 +207,17 @@ namespace ethra.V1
 	public void GetAllItems()
 		{
 		// this will get called after all the manager's have been initialized and start loading all the game item refrences into the master repository
-		DB.FillSQLRepo(ItemConn);
+		if (string.IsNullOrWhiteSpace(ItemCsvPath))
+		{
+			GD.PushWarning("GetAllItems: ItemCsvPath is empty. Skipping item csv load.");
+			return;
 		}
+
+			DB.FillCsvRepo(ItemCsvPath, MasterRepository.RepoLoadType.Items, new[]
+				{
+					"id", "name", "category", "description", "rarity", "sell_value", "subtype", "max_stack"
+				});
+			}
 
 	public void GetAllScenes()
 		{
@@ -219,7 +228,13 @@ namespace ethra.V1
 		public void GetAllDialog()
 		{
 			// loads all the dialog trees into the master repository
-			DB.FillSQLRepo(DialogConn);
+			if (string.IsNullOrWhiteSpace(DialogCsvPath))
+			{
+				GD.PushWarning("GetAllDialog: DialogCsvPath is empty. Skipping dialog csv load.");
+				return;
+			}
+
+			DB.FillCsvRepo(DialogCsvPath, MasterRepository.RepoLoadType.Dialog);
 		}
 		#endregion
 
@@ -566,9 +581,9 @@ namespace ethra.V1
 		   _inventory.UseItem(id);
 		}
 
-		public void AddItem(int id)
+		public bool AddItem(int id)
 		{
-			_inventory.AddItem(id);
+			return _inventory.AddItem(id);
 		}
 
 		public void DropItem(int id)

--- a/Core/Managers/InventoryManager.cs
+++ b/Core/Managers/InventoryManager.cs
@@ -20,27 +20,39 @@ namespace ethra.V1
         public InventoryManager(MasterRepository db)
         {
             _db = db;
+            _itemDict = new Dictionary<int, int>();
         }
 
 
-        public void AddItem(int id)
+        public bool AddItem(int id)
         {
+            InventoryItem itemData = _db.GetItemFromRepo(id);
+            if(itemData == null)
+            {
+                GD.Print($"Unable to add item to inventory. id:{id} not found in repo.");
+                return false;
+            }
+
+            int maxAllowed = itemData.MaxStack > 0 ? itemData.MaxStack : maxStack;
+
             if(_itemDict.TryGetValue(id, out int count))
             {
-                if(count + 1 < maxStack)
+                if(count + 1 <= maxAllowed)
                 {
                      _itemDict[id] = count + 1;
+                     return true;
                 }
                 else
                 {
-                    GD.Print("Unable to add item to inventory. max stack exceeded.");
-                    DropItem(id);
+                    GD.Print($"Unable to add item to inventory. max stack exceeded for id:{id}.");
+                    return false;
                 }
                
             }
             else
             {
                 _itemDict.Add(id, 1);
+                return true;
             }
         }
 
@@ -67,9 +79,16 @@ namespace ethra.V1
 
         public void RestoreSnapshot(object snapshot)
         {
-            if(snapshot is List<int> items)
+            if(snapshot is List<int> listItems)
             {
-                foreach(int i in items)
+                foreach(int i in listItems)
+                {
+                    AddItem(i);
+                }
+            }
+            else if(snapshot is int[] arrayItems)
+            {
+                foreach(int i in arrayItems)
                 {
                     AddItem(i);
                 }
@@ -97,4 +116,3 @@ namespace ethra.V1
 
     }
 }
-

--- a/Core/Managers/MasterRepository.cs
+++ b/Core/Managers/MasterRepository.cs
@@ -1,28 +1,31 @@
-
-
-
-
 using System;
 using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
 using Godot;
 
 namespace ethra.V1
 {
 	public partial class MasterRepository
-{
-	//=========== fields and Properties ==================//
-	// this scene repo is for game levels
-	private Dictionary<string, PackedScene> _sceneRepo;
+	{
+		public enum RepoLoadType
+		{
+			Items,
+			Dialog,
+			Entity
+		}
 
-	private Dictionary<int, InventoryItem> _itemRepo;
+		//=========== fields and Properties ==================//
+		// this scene repo is for game levels
+		private Dictionary<string, PackedScene> _sceneRepo;
 
+		private Dictionary<int, InventoryItem> _itemRepo;
 
 		public MasterRepository()
 		{
 			_sceneRepo = new Dictionary<string, PackedScene>();
 			_itemRepo = new Dictionary<int, InventoryItem>();
 		}
-
 
 		// dialog repo is a dictionary with and int for id and a DialogNode class object <int, DialogNode>
 
@@ -34,7 +37,7 @@ namespace ethra.V1
 		// ============ public facing methods =================//
 
 		public void FillSceneRepo(string rootPath)
-	{
+		{
 			if (string.IsNullOrWhiteSpace(rootPath))
 			{
 				GD.PushError("FillSceneRepo: rootPath is empty.");
@@ -55,6 +58,64 @@ namespace ethra.V1
 			GD.Print($"FillSceneRepo: loaded {added} scenes from {rootPath}");
 		}
 
+		public void FillSQLRepo(string path)
+		{
+			// the item, dialog and Entity objects will be stored in an SQLite DB the path will determine which table to pull form
+			// likely use a switch statement that will parse the response, create the object type and add it to the proper dictionary
+		}
+
+		public void FillCsvRepo(string path, RepoLoadType loadType, IEnumerable<string> requiredHeaders = null)
+		{
+			if (string.IsNullOrWhiteSpace(path))
+			{
+				GD.PushError("FillCsvRepo: csv path is empty.");
+				return;
+			}
+
+			if (!FileAccess.FileExists(path))
+			{
+				GD.PushError($"FillCsvRepo: file does not exist: {path}");
+				return;
+			}
+
+			var rows = ReadCsvRows(path);
+			if (rows.Count == 0)
+			{
+				GD.PushError($"FillCsvRepo: no rows found in csv: {path}");
+				return;
+			}
+
+			var headers = rows[0];
+			if (!ValidateHeaders(headers, requiredHeaders))
+			{
+				GD.PushError($"FillCsvRepo: required headers missing for {loadType} csv: {path}");
+				return;
+			}
+
+			switch (loadType)
+			{
+				case RepoLoadType.Items:
+					LoadItemsFromCsv(headers, rows, path);
+					break;
+				case RepoLoadType.Dialog:
+					GD.Print($"FillCsvRepo: dialog loader not implemented yet. source={path}");
+					break;
+				case RepoLoadType.Entity:
+					GD.Print($"FillCsvRepo: entity loader not implemented yet. source={path}");
+					break;
+			}
+		}
+
+		public PackedScene GetSceneFromRepo(string sceneName)
+		{
+			if (string.IsNullOrWhiteSpace(sceneName)) return null;
+			return _sceneRepo.TryGetValue(sceneName, out var data) ? data : null;
+		}
+
+		public InventoryItem GetItemFromRepo(int id)
+		{
+			return _itemRepo.TryGetValue(id, out var item) ? item : null;
+		}
 
 		private void ScanDirRecursive(string dirPath, ref int added)
 		{
@@ -101,25 +162,204 @@ namespace ethra.V1
 			dir.ListDirEnd();
 		}
 
-		public void FillSQLRepo(string path)
-	{
-		// the item, dialog and Entity objects will be stored in an SQLite DB the path will determine which table to pull form
-		// likely use a switch statement that will parse the response, create the object type and add it to the proper dictionary
-
-	}
-	
-	public PackedScene GetSceneFromRepo(string sceneName)
+		private bool ValidateHeaders(IReadOnlyList<string> headers, IEnumerable<string> requiredHeaders)
 		{
-			if (string.IsNullOrWhiteSpace(sceneName)) return null;
-			return _sceneRepo.TryGetValue(sceneName, out var data) ? data : null;
+			if (requiredHeaders == null)
+			{
+				return true;
+			}
 
+			HashSet<string> headerSet = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+			foreach (string header in headers)
+			{
+				headerSet.Add(header.Trim());
+			}
+
+			foreach (string required in requiredHeaders)
+			{
+				if (!headerSet.Contains(required))
+				{
+					GD.PushError($"FillCsvRepo: missing required header '{required}'.");
+					return false;
+				}
+			}
+
+			return true;
 		}
-	
-	public InventoryItem GetItemFromRepo(int id)
+
+		private List<string[]> ReadCsvRows(string path)
 		{
-			return _itemRepo.TryGetValue(id, out var item) ? item : null;
+			List<string[]> rows = new List<string[]>();
+
+			using FileAccess file = FileAccess.Open(path, FileAccess.ModeFlags.Read);
+			if (file == null)
+			{
+				GD.PushError($"FillCsvRepo: unable to open file {path}");
+				return rows;
+			}
+
+			while (!file.EofReached())
+			{
+				string line = file.GetLine();
+				if (string.IsNullOrWhiteSpace(line))
+				{
+					continue;
+				}
+
+				rows.Add(ParseCsvLine(line));
+			}
+
+			return rows;
 		}
 
-	   
+		private string[] ParseCsvLine(string line)
+		{
+			List<string> values = new List<string>();
+			StringBuilder token = new StringBuilder();
+			bool inQuotes = false;
+
+			for (int i = 0; i < line.Length; i++)
+			{
+				char c = line[i];
+
+				if (c == '"')
+				{
+					bool isEscapedQuote = inQuotes && i + 1 < line.Length && line[i + 1] == '"';
+					if (isEscapedQuote)
+					{
+						token.Append('"');
+						i++;
+					}
+					else
+					{
+						inQuotes = !inQuotes;
+					}
+					continue;
+				}
+
+				if (c == ',' && !inQuotes)
+				{
+					values.Add(token.ToString().Trim());
+					token.Clear();
+					continue;
+				}
+
+				token.Append(c);
+			}
+
+			values.Add(token.ToString().Trim());
+			return values.ToArray();
+		}
+
+		private void LoadItemsFromCsv(IReadOnlyList<string> headers, IReadOnlyList<string[]> rows, string sourcePath)
+		{
+			Dictionary<string, int> headerIndex = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+			for (int i = 0; i < headers.Count; i++)
+			{
+				headerIndex[headers[i].Trim()] = i;
+			}
+
+			_itemRepo.Clear();
+			int loaded = 0;
+			int skipped = 0;
+
+			for (int rowIndex = 1; rowIndex < rows.Count; rowIndex++)
+			{
+				string[] row = rows[rowIndex];
+
+				if (!TryGetInt(headerIndex, row, "id", out int id))
+				{
+					skipped++;
+					GD.PushError($"LoadItemsFromCsv: row {rowIndex + 1} missing/invalid id.");
+					continue;
+				}
+
+				string name = GetString(headerIndex, row, "name");
+				if (string.IsNullOrWhiteSpace(name))
+				{
+					skipped++;
+					GD.PushError($"LoadItemsFromCsv: row {rowIndex + 1} has empty name for id {id}.");
+					continue;
+				}
+
+					string description = GetString(headerIndex, row, "description");
+					string rarity = GetString(headerIndex, row, "rarity");
+					string category = GetString(headerIndex, row, "category");
+					string subtype = GetString(headerIndex, row, "subtype");
+					int value = GetIntOrDefault(headerIndex, row, "sell_value", 0);
+					int maxStack = GetIntOrDefault(headerIndex, row, "max_stack", 99);
+
+				if (_itemRepo.ContainsKey(id))
+				{
+					skipped++;
+					GD.PushError($"LoadItemsFromCsv: duplicate item id {id} at row {rowIndex + 1}.");
+					continue;
+				}
+
+					InventoryItem item = CreateInventoryItem(
+						id,
+						name,
+						value,
+						description,
+						rarity,
+						category,
+						subtype,
+						maxStack);
+					_itemRepo.Add(id, item);
+					loaded++;
+				}
+
+				GD.Print($"LoadItemsFromCsv: loaded={loaded} skipped={skipped} source={sourcePath}");
+			}
+
+			private InventoryItem CreateInventoryItem(
+				int id,
+				string name,
+				int value,
+				string description,
+				string rarity,
+				string category,
+				string subtype,
+				int maxStack)
+			{
+				if (string.Equals(category, "Crafting", StringComparison.OrdinalIgnoreCase))
+				{
+					return new CraftingItem(id, name, value, description, rarity, subtype, maxStack);
+				}
+
+				return new BasicInventoryItem(id, name, value, description, rarity, category: category, subtype: subtype, maxStack: maxStack);
+			}
+
+		private string GetString(Dictionary<string, int> headerIndex, string[] row, string headerName)
+		{
+			if (!headerIndex.TryGetValue(headerName, out int index))
+			{
+				return string.Empty;
+			}
+
+			if (index < 0 || index >= row.Length)
+			{
+				return string.Empty;
+			}
+
+			return row[index].Trim();
+		}
+
+		private bool TryGetInt(Dictionary<string, int> headerIndex, string[] row, string headerName, out int value)
+		{
+			value = 0;
+			string raw = GetString(headerIndex, row, headerName);
+			return int.TryParse(raw, NumberStyles.Integer, CultureInfo.InvariantCulture, out value);
+		}
+
+		private int GetIntOrDefault(Dictionary<string, int> headerIndex, string[] row, string headerName, int defaultValue)
+		{
+			if (TryGetInt(headerIndex, row, headerName, out int parsed))
+			{
+				return parsed;
+			}
+
+			return defaultValue;
+		}
 	}
 }

--- a/Core/Nodes/Interactable/ItemPickup.cs
+++ b/Core/Nodes/Interactable/ItemPickup.cs
@@ -1,0 +1,86 @@
+using Godot;
+
+namespace ethra.V1
+{
+    public partial class ItemPickup : Area2D
+    {
+        [Export] public int ItemId { get; set; }
+        [Export] public int Quantity { get; set; } = 1;
+        [Export] public bool RequireInteract { get; set; } = true;
+
+        private bool _playerInside;
+
+        public override void _Ready()
+        {
+            BodyEntered += OnBodyEntered;
+            BodyExited += OnBodyExited;
+        }
+
+        public override void _Process(double delta)
+        {
+            if (!RequireInteract || !_playerInside)
+            {
+                return;
+            }
+
+            if (Input.IsActionJustPressed("Interact"))
+            {
+                TryPickup();
+            }
+        }
+
+        private void OnBodyEntered(Node2D body)
+        {
+            if (body is not PlayerNode)
+            {
+                return;
+            }
+
+            _playerInside = true;
+            if (!RequireInteract)
+            {
+                TryPickup();
+            }
+        }
+
+        private void OnBodyExited(Node2D body)
+        {
+            if (body is PlayerNode)
+            {
+                _playerInside = false;
+            }
+        }
+
+        private void TryPickup()
+        {
+            var gm = GameManager.Instance;
+            if (gm == null)
+            {
+                GD.PushError("ItemPickup: GameManager.Instance was null.");
+                return;
+            }
+
+            int attempts = Quantity > 0 ? Quantity : 1;
+            int added = 0;
+
+            for (int i = 0; i < attempts; i++)
+            {
+                if (!gm.AddItem(ItemId))
+                {
+                    break;
+                }
+
+                added++;
+            }
+
+            if (added == attempts)
+            {
+                QueueFree();
+            }
+            else
+            {
+                GD.Print($"ItemPickup: pickup incomplete for item {ItemId}. added={added}/{attempts}");
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide a CSV-backed master repository for items so game data can be authored outside of a database and loaded at runtime.
- Model inventory items with richer metadata (category, subtype, max stack, effects) and enable per-item stack limits.
- Make `AddItem` report success/failure and allow world pickups to add items to the player inventory.

### Description
- Added CSV seed `Core/Inventory/Data/items_seed.csv` and implemented CSV parsing and loading in `MasterRepository` via `FillCsvRepo`, `ReadCsvRows`, `ParseCsvLine`, and `LoadItemsFromCsv` with header validation and item creation logic for `BasicInventoryItem` and `CraftingItem`.
- Introduced `InventoryItem` base refactor to expose `Category`, `Subtype`, `MaxStack`, and improved `GetInfo` and `Use` behavior, plus concrete classes `BasicInventoryItem` and `CraftingItem` with specialized `Use` semantics.
- Changed `IInventory.AddItem` signature to return `bool` and updated `InventoryManager` and `GameManager` to handle boolean success, with `InventoryManager` tracking item counts, respecting per-item `MaxStack`, supporting snapshot capture/restore, and using the repository to validate items.
- Added `ItemPickup` Area2D node to enable in-world item pickups that attempt to add items via `GameManager.AddItem` and optionally auto-free on complete pickup, and updated `GameManager` exports to use `DialogCsvPath` and `ItemCsvPath` and to call `DB.FillCsvRepo` for items and dialog.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e000462e58832686476892f6feeb70)