### PR TITLE
Add inventory UI components and InventoryManager change notifications

### DIFF
--- a/Core/Managers/InventoryManager.cs
+++ b/Core/Managers/InventoryManager.cs
@@ -16,6 +16,7 @@ namespace ethra.V1
         private Dictionary<string, int> _equippedWeaponBySlot;
         private int maxStack = 99;
         private readonly MasterRepository _db;
+        public event Action Changed;
 
 		public string SaveKey => _saveKey;
 
@@ -44,6 +45,7 @@ namespace ethra.V1
                 if(count + 1 <= maxAllowed)
                 {
                      _itemDict[id] = count + 1;
+                     NotifyChanged();
                      return true;
                 }
                 else
@@ -56,6 +58,7 @@ namespace ethra.V1
             else
             {
                 _itemDict.Add(id, 1);
+                NotifyChanged();
                 return true;
             }
         }
@@ -114,12 +117,14 @@ namespace ethra.V1
                 if (itemToUse is ArmorItem armor)
                 {
                     ToggleArmorEquip(armor);
+                    NotifyChanged();
                     return;
                 }
 
                 if (itemToUse is WeaponItem weapon)
                 {
                     ToggleWeaponEquip(weapon);
+                    NotifyChanged();
                     return;
                 }
 
@@ -128,6 +133,7 @@ namespace ethra.V1
                 if (itemToUse is ConsumeItem)
                 {
                     ConsumeOne(id);
+                    NotifyChanged();
                 }
             }
             else
@@ -203,6 +209,26 @@ namespace ethra.V1
             {
                 _itemDict[id] = currentCount - 1;
             }
+        }
+
+        public IReadOnlyDictionary<int, int> GetItemCounts()
+        {
+            return _itemDict;
+        }
+
+        public IReadOnlyDictionary<string, int> GetEquippedWeapons()
+        {
+            return _equippedWeaponBySlot;
+        }
+
+        public IReadOnlyDictionary<string, int> GetEquippedArmor()
+        {
+            return _equippedArmorBySlot;
+        }
+
+        private void NotifyChanged()
+        {
+            Changed?.Invoke();
         }
 
 

--- a/Core/UI/Scripts/InventorySlotView.cs
+++ b/Core/UI/Scripts/InventorySlotView.cs
@@ -1,0 +1,71 @@
+using Godot;
+using System;
+using ethra.V1;
+
+public partial class InventorySlotView : Button
+{
+    [Export] private TextureRect Icon;
+    [Export] private Label QuantityLabel;
+    [Export] private TextureRect Selector;
+
+    public int? ItemId { get; private set; }
+    public int Count { get; private set; }
+    public InventoryItem ItemData { get; private set; }
+
+    public event Action<InventorySlotView> Clicked;
+
+    public override void _Ready()
+    {
+        Pressed += OnPressed;
+        SetSelected(false);
+    }
+
+    public void SetEmpty()
+    {
+        ItemId = null;
+        Count = 0;
+        ItemData = null;
+
+        if (QuantityLabel != null)
+        {
+            QuantityLabel.Text = string.Empty;
+        }
+
+        if (Icon != null)
+        {
+            Icon.Visible = false;
+        }
+
+        SetSelected(false);
+    }
+
+    public void SetItem(InventoryItem item, int count)
+    {
+        ItemData = item;
+        ItemId = item?.Id;
+        Count = count;
+
+        if (QuantityLabel != null)
+        {
+            QuantityLabel.Text = count > 1 ? count.ToString() : string.Empty;
+        }
+
+        if (Icon != null)
+        {
+            Icon.Visible = item != null;
+        }
+    }
+
+    public void SetSelected(bool isSelected)
+    {
+        if (Selector != null)
+        {
+            Selector.Visible = isSelected;
+        }
+    }
+
+    private void OnPressed()
+    {
+        Clicked?.Invoke(this);
+    }
+}

--- a/Core/UI/Scripts/PlayerMenu.cs
+++ b/Core/UI/Scripts/PlayerMenu.cs
@@ -1,0 +1,246 @@
+using Godot;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using ethra.V1;
+
+public partial class PlayerMenu : Control
+{
+    [Export] private GridContainer InventoryGrid;
+    [Export] private InventorySlotView EquippedWeaponSlot;
+    [Export] private InventorySlotView EquippedArmorSlot;
+    [Export] private RichTextLabel ToolTip;
+    [Export] private RichTextLabel StatsStatus;
+
+    private readonly List<InventorySlotView> _inventorySlots = new();
+    private InventoryManager _inventory;
+    private MasterRepository _repo;
+    private InventorySlotView _selectedSlot;
+
+    public override void _Ready()
+    {
+        GameManager gm = GameManager.Instance;
+        if (gm == null)
+        {
+            GD.PushWarning("PlayerMenu: GameManager.Instance is null.");
+            return;
+        }
+
+        _inventory = gm.Inventory;
+        _repo = gm.DB;
+
+        CacheInventorySlots();
+        BindEquipmentSlots();
+
+        if (_inventory != null)
+        {
+            _inventory.Changed += RefreshAll;
+        }
+
+        RefreshAll();
+    }
+
+    public override void _ExitTree()
+    {
+        if (_inventory != null)
+        {
+            _inventory.Changed -= RefreshAll;
+        }
+
+        foreach (InventorySlotView slot in _inventorySlots)
+        {
+            slot.Clicked -= OnSlotClicked;
+        }
+
+        if (EquippedWeaponSlot != null)
+        {
+            EquippedWeaponSlot.Clicked -= OnSlotClicked;
+        }
+
+        if (EquippedArmorSlot != null)
+        {
+            EquippedArmorSlot.Clicked -= OnSlotClicked;
+        }
+    }
+
+    private void CacheInventorySlots()
+    {
+        _inventorySlots.Clear();
+
+        if (InventoryGrid == null)
+        {
+            GD.PushWarning("PlayerMenu: InventoryGrid export is not assigned.");
+            return;
+        }
+
+        foreach (Node child in InventoryGrid.GetChildren())
+        {
+            if (child is InventorySlotView slot)
+            {
+                slot.Clicked += OnSlotClicked;
+                _inventorySlots.Add(slot);
+            }
+        }
+    }
+
+    private void BindEquipmentSlots()
+    {
+        if (EquippedWeaponSlot != null)
+        {
+            EquippedWeaponSlot.Clicked += OnSlotClicked;
+        }
+
+        if (EquippedArmorSlot != null)
+        {
+            EquippedArmorSlot.Clicked += OnSlotClicked;
+        }
+    }
+
+    private void RefreshAll()
+    {
+        RefreshInventoryGrid();
+        RefreshEquipmentSlots();
+        RefreshDetails(_selectedSlot);
+    }
+
+    private void RefreshInventoryGrid()
+    {
+        if (_inventory == null || _repo == null)
+        {
+            return;
+        }
+
+        List<KeyValuePair<int, int>> items = _inventory.GetItemCounts()
+            .OrderBy(pair => pair.Key)
+            .ToList();
+
+        for (int i = 0; i < _inventorySlots.Count; i++)
+        {
+            if (i >= items.Count)
+            {
+                _inventorySlots[i].SetEmpty();
+                continue;
+            }
+
+            KeyValuePair<int, int> entry = items[i];
+            InventoryItem item = _repo.GetItemFromRepo(entry.Key);
+
+            if (item == null)
+            {
+                _inventorySlots[i].SetEmpty();
+                continue;
+            }
+
+            _inventorySlots[i].SetItem(item, entry.Value);
+        }
+    }
+
+    private void RefreshEquipmentSlots()
+    {
+        if (_inventory == null || _repo == null)
+        {
+            return;
+        }
+
+        SetEquipmentSlot(EquippedWeaponSlot, _inventory.GetEquippedWeapons(), "MainHand");
+        SetEquipmentSlot(EquippedArmorSlot, _inventory.GetEquippedArmor(), "Armor");
+    }
+
+    private void SetEquipmentSlot(InventorySlotView slotView, IReadOnlyDictionary<string, int> equipped, string slotKey)
+    {
+        if (slotView == null)
+        {
+            return;
+        }
+
+        if (equipped == null || !equipped.TryGetValue(slotKey, out int itemId))
+        {
+            slotView.SetEmpty();
+            return;
+        }
+
+        InventoryItem item = _repo.GetItemFromRepo(itemId);
+        if (item == null)
+        {
+            slotView.SetEmpty();
+            return;
+        }
+
+        slotView.SetItem(item, 1);
+    }
+
+    private void OnSlotClicked(InventorySlotView slot)
+    {
+        SelectSlot(slot);
+
+        if (_inventory == null || slot?.ItemId == null)
+        {
+            return;
+        }
+
+        if (slot.ItemData is WeaponItem || slot.ItemData is ArmorItem)
+        {
+            _inventory.UseItem(slot.ItemId.Value);
+            RefreshAll();
+        }
+    }
+
+    private void SelectSlot(InventorySlotView slot)
+    {
+        _selectedSlot = slot;
+
+        foreach (InventorySlotView inventorySlot in _inventorySlots)
+        {
+            inventorySlot.SetSelected(inventorySlot == slot);
+        }
+
+        if (EquippedWeaponSlot != null)
+        {
+            EquippedWeaponSlot.SetSelected(EquippedWeaponSlot == slot);
+        }
+
+        if (EquippedArmorSlot != null)
+        {
+            EquippedArmorSlot.SetSelected(EquippedArmorSlot == slot);
+        }
+
+        RefreshDetails(slot);
+    }
+
+    private void RefreshDetails(InventorySlotView slot)
+    {
+        if (ToolTip == null || StatsStatus == null)
+        {
+            return;
+        }
+
+        if (slot?.ItemData == null)
+        {
+            ToolTip.Text = "Select an item to view its description.";
+            StatsStatus.Text = string.Empty;
+            return;
+        }
+
+        InventoryItem item = slot.ItemData;
+
+        ToolTip.Text = item.Description;
+
+        var details = new StringBuilder();
+        details.AppendLine($"Name: {item.Name}");
+        details.AppendLine($"Category: {item.Category}");
+        details.AppendLine($"Subtype: {item.Subtype}");
+        details.AppendLine($"Rarity: {item.Rarity}");
+        details.AppendLine($"Count: {slot.Count}");
+
+        if (item.Effects != null && item.Effects.Count > 0)
+        {
+            details.AppendLine("Effects:");
+            foreach (ItemEffects effect in item.Effects)
+            {
+                details.AppendLine($"- {effect.EffectName}");
+            }
+        }
+
+        StatsStatus.Text = details.ToString();
+    }
+}

--- a/PackedScenes/EthraV1/Core/UI/inventory_slot.tscn
+++ b/PackedScenes/EthraV1/Core/UI/inventory_slot.tscn
@@ -1,9 +1,10 @@
-[gd_scene load_steps=7 format=3 uid="uid://ckmusyefdjgen"]
+[gd_scene load_steps=8 format=3 uid="uid://ckmusyefdjgen"]
 
 [ext_resource type="Texture2D" uid="uid://d0tt1kw0iosf6" path="res://ArtAssets/UI/Inventory/Inventory_Slot.png" id="1_slioy"]
 [ext_resource type="Texture2D" uid="uid://13nfhxsrmcv3" path="res://ArtAssets/InventoryItems/GearIcons/ArmorIcon.tres" id="2_b6onm"]
 [ext_resource type="FontFile" uid="uid://82lve5ogo12m" path="res://ArtAssets/Fonts/m5x7.ttf" id="3_4sj30"]
 [ext_resource type="Texture2D" uid="uid://egj4yak4x2ve" path="res://ArtAssets/UI/Inventory/MenuIndicate.tres" id="4_daruc"]
+[ext_resource type="Script" path="res://Core/UI/Scripts/InventorySlotView.cs" id="5_menuslot"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_3ikqg"]
 bg_color = Color(0.993338, 0.844762, 0.620774, 1)
@@ -21,7 +22,11 @@ line_spacing = 0.0
 font = ExtResource("3_4sj30")
 font_color = Color(0.144063, 0.144063, 0.144063, 1)
 
-[node name="ItemIcon" type="Button"]
+[node name="ItemIcon" type="Button" node_paths=PackedStringArray("Icon", "QuantityLabel", "Selector")]
+script = ExtResource("5_menuslot")
+Icon = NodePath("Icon")
+QuantityLabel = NodePath("Panel/Label")
+Selector = NodePath("Selector")
 custom_minimum_size = Vector2(26, 26)
 anchors_preset = -1
 anchor_right = 0.081

--- a/PackedScenes/UI/PlayerUI.tscn
+++ b/PackedScenes/UI/PlayerUI.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=19 format=3 uid="uid://dblf2lc3y1xu1"]
+[gd_scene load_steps=20 format=3 uid="uid://dblf2lc3y1xu1"]
 
 [ext_resource type="Texture2D" uid="uid://dwddfu5bc1y1q" path="res://ArtAssets/UI/Icons/LootBag_U.png" id="1_01pqg"]
 [ext_resource type="Theme" uid="uid://dps46k28pmrlj" path="res://PackedScenes/UI/PlayerUI.tres" id="1_2hm7f"]
@@ -16,6 +16,7 @@
 [ext_resource type="Texture2D" uid="uid://d2d8rdvg2v01h" path="res://ArtAssets/UI/Icons/19.png" id="10_d1iv5"]
 [ext_resource type="Texture2D" uid="uid://mrqqt80opvaj" path="res://ArtAssets/UI/Inventory/Inventory_background.png" id="14_c8es7"]
 [ext_resource type="Texture2D" uid="uid://3efrmiudtjk1" path="res://ArtAssets/InventoryItems/GearIcons/tile034.png" id="15_yhkih"]
+[ext_resource type="Script" path="res://components/Inventory/UI/PlayerMenu.cs" id="16_player_menu"]
 
 [sub_resource type="StyleBoxTexture" id="StyleBoxTexture_ggc4l"]
 content_margin_left = 16.0
@@ -39,7 +40,14 @@ texture_margin_top = 12.0
 texture_margin_right = 12.0
 texture_margin_bottom = 12.0
 
-[node name="PlayerUi" type="Control"]
+[node name="PlayerUi" type="Control" node_paths=PackedStringArray("_inventoryGrid", "_weaponSlot", "_armorSlot", "_descriptionLabel", "_statsStatusLabel")]
+script = ExtResource("16_player_menu")
+_inventoryPath = NodePath("")
+_inventoryGrid = NodePath("NinePatchRect/VBoxContainer/Inventory/VBoxContainer2/Inventory")
+_weaponSlot = NodePath("NinePatchRect/VBoxContainer/Inventory/VBoxContainer/PlayerView/HBoxContainer/PlayerEquip/WeaponEquip")
+_armorSlot = NodePath("NinePatchRect/VBoxContainer/Inventory/VBoxContainer/PlayerView/HBoxContainer/PlayerEquip/ArmorEquip")
+_descriptionLabel = NodePath("NinePatchRect/VBoxContainer/Inventory/VBoxContainer/ToolTip")
+_statsStatusLabel = NodePath("NinePatchRect/VBoxContainer/Inventory/VBoxContainer2/Stats_Status")
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
@@ -243,9 +251,11 @@ layout_mode = 2
 [node name="ItemIcon28" parent="NinePatchRect/VBoxContainer/Inventory/VBoxContainer2/Inventory" instance=ExtResource("1_10cgu")]
 layout_mode = 2
 
-[node name="Stats_Status" type="HBoxContainer" parent="NinePatchRect/VBoxContainer/Inventory/VBoxContainer2"]
+[node name="Stats_Status" type="RichTextLabel" parent="NinePatchRect/VBoxContainer/Inventory/VBoxContainer2"]
+custom_minimum_size = Vector2(0, 80)
 layout_mode = 2
 size_flags_vertical = 3
+fit_content = true
 
 [node name="Map" type="HBoxContainer" parent="NinePatchRect/VBoxContainer"]
 visible = false

--- a/components/Inventory/UI/PlayerMenu.cs
+++ b/components/Inventory/UI/PlayerMenu.cs
@@ -1,0 +1,239 @@
+using Godot;
+using System.Collections.Generic;
+using System.Text;
+
+public partial class PlayerMenu : Control
+{
+    [Export] private NodePath _inventoryPath;
+    [Export] private GridContainer _inventoryGrid;
+    [Export] private PlayerMenuSlot _weaponSlot;
+    [Export] private PlayerMenuSlot _armorSlot;
+    [Export] private RichTextLabel _descriptionLabel;
+    [Export] private RichTextLabel _statsStatusLabel;
+
+    private readonly List<PlayerMenuSlot> _inventorySlots = new();
+    private IInventoryReadOnly _inventory;
+
+    private PlayerMenuSlot _selectedSlot;
+    private int _selectedInventoryIndex = -1;
+
+    public override void _Ready()
+    {
+        if (_inventoryPath == null || _inventoryPath.IsEmpty)
+        {
+            GD.PushWarning("PlayerMenu: InventoryPath is not assigned.");
+            return;
+        }
+
+        _inventory = GetNodeOrNull<IInventoryReadOnly>(_inventoryPath);
+        if (_inventory == null)
+        {
+            GD.PushWarning($"PlayerMenu: unable to resolve inventory at '{_inventoryPath}'.");
+            return;
+        }
+
+        BindInventorySlots();
+        BindEquipmentSlot(_weaponSlot, -1);
+        BindEquipmentSlot(_armorSlot, -2);
+
+        if (_weaponSlot != null)
+        {
+            _weaponSlot.SlotPressed += OnAnySlotPressed;
+        }
+
+        if (_armorSlot != null)
+        {
+            _armorSlot.SlotPressed += OnAnySlotPressed;
+        }
+
+        _inventory.Changed += OnInventoryChanged;
+
+        FullRefresh();
+        SelectSlot(null);
+    }
+
+    public override void _ExitTree()
+    {
+        if (_inventory != null)
+        {
+            _inventory.Changed -= OnInventoryChanged;
+        }
+
+        if (_weaponSlot != null)
+        {
+            _weaponSlot.SlotPressed -= OnAnySlotPressed;
+        }
+
+        if (_armorSlot != null)
+        {
+            _armorSlot.SlotPressed -= OnAnySlotPressed;
+        }
+
+        foreach (PlayerMenuSlot slot in _inventorySlots)
+        {
+            slot.SlotPressed -= OnAnySlotPressed;
+        }
+    }
+
+    private void BindInventorySlots()
+    {
+        _inventorySlots.Clear();
+
+        if (_inventoryGrid == null)
+        {
+            GD.PushWarning("PlayerMenu: InventoryGrid is not assigned.");
+            return;
+        }
+
+        int index = 0;
+        foreach (Node child in _inventoryGrid.GetChildren())
+        {
+            if (child is not PlayerMenuSlot slot)
+            {
+                continue;
+            }
+
+            slot.BindSlotIndex(index);
+            slot.SlotPressed += OnAnySlotPressed;
+            slot.SetSelected(false);
+            _inventorySlots.Add(slot);
+            index++;
+        }
+    }
+
+    private static void BindEquipmentSlot(PlayerMenuSlot slot, int slotIndex)
+    {
+        if (slot == null)
+        {
+            return;
+        }
+
+        slot.BindSlotIndex(slotIndex);
+    }
+
+    private void OnInventoryChanged(InventoryChange _)
+    {
+        FullRefresh();
+        RefreshSelectionText();
+    }
+
+    private void FullRefresh()
+    {
+        if (_inventory == null)
+        {
+            return;
+        }
+
+        int count = Mathf.Min(_inventorySlots.Count, _inventory.Slots.Count);
+        for (int i = 0; i < count; i++)
+        {
+            _inventorySlots[i].SetStack(_inventory.Slots[i]);
+        }
+
+        for (int i = count; i < _inventorySlots.Count; i++)
+        {
+            _inventorySlots[i].SetStack(null);
+        }
+
+        ItemStack? weapon = null;
+        ItemStack? armor = null;
+
+        _inventory.Equipped.TryGetValue(EquipmentSlot.Weapon, out weapon);
+        _inventory.Equipped.TryGetValue(EquipmentSlot.Armor, out armor);
+
+        if (_weaponSlot != null)
+        {
+            _weaponSlot.SetStack(weapon);
+        }
+
+        if (_armorSlot != null)
+        {
+            _armorSlot.SetStack(armor);
+        }
+    }
+
+    private void OnAnySlotPressed(PlayerMenuSlot slot)
+    {
+        SelectSlot(slot);
+
+        if (slot == null || slot.SlotIndex < 0 || slot.Stack == null)
+        {
+            return;
+        }
+
+        InventoryItem item = InventoryManager.I.Get(slot.Stack.ItemId);
+
+        if (item.itemType == ItemType.Weapon || item.itemType == ItemType.Armor)
+        {
+            EventManager.I.Publish(GameEvent.UseItem, new UseItemRequest(slot.Stack, slot.SlotIndex));
+        }
+    }
+
+    private void SelectSlot(PlayerMenuSlot slot)
+    {
+        _selectedSlot = slot;
+        _selectedInventoryIndex = slot != null ? slot.SlotIndex : -1;
+
+        foreach (PlayerMenuSlot invSlot in _inventorySlots)
+        {
+            invSlot.SetSelected(invSlot == slot);
+        }
+
+        if (_weaponSlot != null)
+        {
+            _weaponSlot.SetSelected(_weaponSlot == slot);
+        }
+
+        if (_armorSlot != null)
+        {
+            _armorSlot.SetSelected(_armorSlot == slot);
+        }
+
+        RefreshSelectionText();
+    }
+
+    private void RefreshSelectionText()
+    {
+        if (_descriptionLabel == null || _statsStatusLabel == null)
+        {
+            return;
+        }
+
+        if (_selectedSlot == null || _selectedSlot.Stack == null)
+        {
+            _descriptionLabel.Text = "Select an item to view details.";
+            _statsStatusLabel.Text = "";
+            return;
+        }
+
+        InventoryItem item = InventoryManager.I.Get(_selectedSlot.Stack.ItemId);
+
+        _descriptionLabel.Text = item.ItemDescription;
+
+        var details = new StringBuilder();
+        details.AppendLine($"Name: {item.ItemName}");
+        details.AppendLine($"Type: {item.itemType}");
+        details.AppendLine($"Rarity: {item.Rarity}");
+        details.AppendLine($"Stack: {_selectedSlot.Stack.Count}/{item.ItemStackSize}");
+
+        if (item.Actions != null && item.Actions.Length > 0)
+        {
+            details.AppendLine("Effects:");
+            foreach (ItemAction action in item.Actions)
+            {
+                if (action != null)
+                {
+                    details.AppendLine($"- {action.ResourceName}");
+                }
+            }
+        }
+
+        if (_selectedInventoryIndex >= 0 && (item.itemType == ItemType.Weapon || item.itemType == ItemType.Armor))
+        {
+            details.AppendLine();
+            details.AppendLine("Click again to swap this equipment.");
+        }
+
+        _statsStatusLabel.Text = details.ToString();
+    }
+}

--- a/components/Inventory/UI/PlayerMenuSlot.cs
+++ b/components/Inventory/UI/PlayerMenuSlot.cs
@@ -1,0 +1,72 @@
+using Godot;
+using System;
+
+public partial class PlayerMenuSlot : Button
+{
+    [Export] private TextureRect _icon;
+    [Export] private Label _quantity;
+    [Export] private TextureRect _selector;
+
+    public int SlotIndex { get; private set; } = -1;
+    public ItemStack? Stack { get; private set; }
+
+    public event Action<PlayerMenuSlot>? SlotPressed;
+
+    public override void _Ready()
+    {
+        Pressed += OnPressed;
+        SetSelected(false);
+    }
+
+    public void BindSlotIndex(int slotIndex)
+    {
+        SlotIndex = slotIndex;
+    }
+
+    public void SetStack(ItemStack? stack)
+    {
+        Stack = stack;
+
+        if (stack == null)
+        {
+            if (_icon != null)
+            {
+                _icon.Texture = null;
+                _icon.Visible = false;
+            }
+
+            if (_quantity != null)
+            {
+                _quantity.Text = string.Empty;
+            }
+
+            return;
+        }
+
+        InventoryItem item = InventoryManager.I.Get(stack.ItemId);
+
+        if (_icon != null)
+        {
+            _icon.Texture = item.IconSprite;
+            _icon.Visible = item.IconSprite != null;
+        }
+
+        if (_quantity != null)
+        {
+            _quantity.Text = stack.Count > 1 ? stack.Count.ToString() : string.Empty;
+        }
+    }
+
+    public void SetSelected(bool selected)
+    {
+        if (_selector != null)
+        {
+            _selector.Visible = selected;
+        }
+    }
+
+    private void OnPressed()
+    {
+        SlotPressed?.Invoke(this);
+    }
+}

--- a/components/Inventory/base/InventoryComponent.cs
+++ b/components/Inventory/base/InventoryComponent.cs
@@ -118,9 +118,9 @@ public partial class InventoryComponent : Node , IInventoryReadOnly
             remove |= act.Execute(owner, this, data);   // execute every action
 
 
-        if (data.itemType == ItemType.Weapon)
+        if (data.itemType == ItemType.Weapon || data.itemType == ItemType.Armor)
         {
-            GD.Print("clicked an weapon item");
+            GD.Print("clicked an equippable item");
             Equip(request.slot);
         }
 


### PR DESCRIPTION
### Motivation

- Allow UI to react to inventory changes by emitting change notifications from the inventory layer.
- Expose read-only inventory data (counts and equipped items) so UI can render current state without tight coupling.
- Provide reusable UI controls for inventory slots and an in-game player menu to display inventory and equipment.
- Ensure equippable armor is handled the same as weapons in the inventory component when a slot is used.

### Description

- Added a `Changed` event and `NotifyChanged()` helper to `InventoryManager` and call it on item add/use/consume operations, and added read-only accessors `GetItemCounts()`, `GetEquippedWeapons()`, and `GetEquippedArmor()`.
- Introduced `InventorySlotView.cs` and `PlayerMenu.cs` UI scripts (under `Core/UI/Scripts` and `components/Inventory/UI`) along with `PlayerMenuSlot.cs` to render slots, selection, tooltips and to wire clicks into inventory actions.
- Updated packed scene files (`inventory_slot.tscn` and `PlayerUI.tscn`) to reference the new slot and menu scripts and to expose node paths for binding the UI.
- Adjusted `InventoryComponent.UseSlot` to treat `ItemType.Armor` the same as `ItemType.Weapon` for equip behavior and updated the log text; ensured `NotifyChange` is emitted after a use operation.

### Testing

- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3be5faaf48326bf23a1018320ebdd)