### PR TITLE
Inventory: CSV-backed items & effects, equipment, pickups, UI and repo loader

### DIFF
--- a/Core/Inventory/Data/item_effects_seed.csv
+++ b/Core/Inventory/Data/item_effects_seed.csv
@@ -1,0 +1,7 @@
+item_id,effect_type,effect_stat,effect_power
+2001,plus,str,2
+2002,plus,str,4
+2002,plus,dex,1
+4001,plus,vit,1
+4002,plus,dex,2
+4101,plus,vit,3

--- a/Core/Inventory/Data/items_seed.csv
+++ b/Core/Inventory/Data/items_seed.csv
@@ -1,0 +1,8 @@
+id,name,description,rarity,sell_value,category,subtype,max_stack
+1001,Small Health Potion,Restores a small amount of HP,Common,5,Consumable,Potion,99
+2001,Rusted Sword,An old blade with low durability,Common,10,Weapon,Sword,1
+2002,Iron Longsword,Reliable steel blade,Uncommon,18,Weapon,Sword,1
+3001,Copper Ore,Base crafting ore,Common,2,Crafting,Ore,99
+4001,Leather Cap,Simple head protection,Common,8,Armor,Head,1
+4002,Traveler Hood,Lightweight hood armor,Uncommon,12,Armor,Head,1
+4101,Padded Vest,Simple chest protection,Common,9,Armor,Chest,1

--- a/Core/Inventory/Interfaces/IInventory.cs
+++ b/Core/Inventory/Interfaces/IInventory.cs
@@ -7,7 +7,7 @@ namespace ethra.V1
         
         void UseItem(int id);
 
-        void AddItem(int id);
+        bool AddItem(int id);
 
         void DropItem(int id);
 

--- a/Core/Inventory/Scripts/ArmorItem.cs
+++ b/Core/Inventory/Scripts/ArmorItem.cs
@@ -1,0 +1,76 @@
+using Godot;
+using System.Collections.Generic;
+
+namespace ethra.V1
+{
+    public class ArmorItem : InventoryItem
+    {
+        private bool _isEquipped;
+
+        public string ArmorSlot => Subtype;
+        public bool IsEquipped => _isEquipped;
+
+        public ArmorItem(
+            int id,
+            string name,
+            int value,
+            string description,
+            string rarity,
+            string slot,
+            int maxStack,
+            List<ItemEffects> effects = null)
+            : base(id, name, value, description, rarity, effects, category: "Armor", subtype: slot, maxStack: maxStack)
+        {
+        }
+
+        public void Equip()
+        {
+            if (_isEquipped)
+            {
+                return;
+            }
+
+            foreach (ItemEffects effect in Effects)
+            {
+                if (effect is IEffect itemEffect)
+                {
+                    itemEffect.ResolveItemEffect();
+                }
+            }
+
+            _isEquipped = true;
+            GD.Print($"Equipped armor '{Name}' in slot '{ArmorSlot}'.");
+        }
+
+        public void Unequip()
+        {
+            if (!_isEquipped)
+            {
+                return;
+            }
+
+            foreach (ItemEffects effect in Effects)
+            {
+                if (effect is IEffect itemEffect)
+                {
+                    itemEffect.RemoveItemEffect();
+                }
+            }
+
+            _isEquipped = false;
+            GD.Print($"Unequipped armor '{Name}' from slot '{ArmorSlot}'.");
+        }
+
+        public override void Use()
+        {
+            if (IsEquipped)
+            {
+                Unequip();
+            }
+            else
+            {
+                Equip();
+            }
+        }
+    }
+}

--- a/Core/Inventory/Scripts/BasicInventoryItem.cs
+++ b/Core/Inventory/Scripts/BasicInventoryItem.cs
@@ -1,0 +1,21 @@
+using System.Collections.Generic;
+
+namespace ethra.V1
+{
+    public class BasicInventoryItem : InventoryItem
+    {
+        public BasicInventoryItem(
+            int id,
+            string name,
+            int value,
+            string description,
+            string rarity,
+            List<ItemEffects> effects = null,
+            string category = "",
+            string subtype = "",
+            int maxStack = 99)
+            : base(id, name, value, description, rarity, effects, category, subtype, maxStack)
+        {
+        }
+    }
+}

--- a/Core/Inventory/Scripts/ConsumeItem.cs
+++ b/Core/Inventory/Scripts/ConsumeItem.cs
@@ -1,0 +1,44 @@
+using Godot;
+using System.Collections.Generic;
+
+namespace ethra.V1
+{
+    public class ConsumeItem : InventoryItem
+    {
+        public string ConsumeType => Subtype;
+
+        public ConsumeItem(
+            int id,
+            string name,
+            int value,
+            string description,
+            string rarity,
+            string subtype,
+            int maxStack,
+            List<ItemEffects> effects = null)
+            : base(id, name, value, description, rarity, effects, category: "Consumable", subtype: subtype, maxStack: maxStack)
+        {
+        }
+
+        public override void Use()
+        {
+            int healAmount = 0;
+
+            foreach (ItemEffects effect in Effects)
+            {
+                if (effect is IEffect itemEffect)
+                {
+                    itemEffect.ResolveItemEffect();
+                }
+            }
+
+            if (Owner is IStats stats && string.Equals(ConsumeType, "Potion", System.StringComparison.OrdinalIgnoreCase))
+            {
+                healAmount = 25;
+                stats.CurHP = healAmount;
+            }
+
+            GD.Print($"Consumed item '{Name}' [{ConsumeType}] heal={healAmount}.");
+        }
+    }
+}

--- a/Core/Inventory/Scripts/CraftingItem.cs
+++ b/Core/Inventory/Scripts/CraftingItem.cs
@@ -1,0 +1,28 @@
+using Godot;
+using System.Collections.Generic;
+
+namespace ethra.V1
+{
+    public class CraftingItem : InventoryItem
+    {
+        public string MaterialType => Subtype;
+
+        public CraftingItem(
+            int id,
+            string name,
+            int value,
+            string description,
+            string rarity,
+            string subtype,
+            int maxStack,
+            List<ItemEffects> effects = null)
+            : base(id, name, value, description, rarity, effects, category: "Crafting", subtype: subtype, maxStack: maxStack)
+        {
+        }
+
+        public override void Use()
+        {
+            GD.Print($"Crafting item '{Name}' cannot be used directly.");
+        }
+    }
+}

--- a/Core/Inventory/Scripts/Effects/MinusStat.cs
+++ b/Core/Inventory/Scripts/Effects/MinusStat.cs
@@ -14,17 +14,64 @@ namespace ethra.V1
         }
         public void RemoveItemEffect()
         {
-            throw new System.NotImplementedException();
+            if (Owner is not IStats stats)
+            {
+                return;
+            }
+
+            ModifyStat(stats, EffectPower);
         }
 
         public void ResolveItemEffect()
         {
-            throw new System.NotImplementedException();
+            if (Owner is not IStats stats)
+            {
+                return;
+            }
+
+            ModifyStat(stats, -EffectPower);
+        }
+
+        private void ModifyStat(IStats stats, int delta)
+        {
+            switch (StatKey.ToLowerInvariant())
+            {
+                case "maxhp":
+                    stats.MaxHP += delta;
+                    break;
+                case "maxmana":
+                    stats.MaxMana += delta;
+                    break;
+                case "strength":
+                case "str":
+                    stats.Strength += delta;
+                    break;
+                case "dexterity":
+                case "dex":
+                    stats.Dexterity += delta;
+                    break;
+                case "intelligence":
+                case "int":
+                    stats.Intelligence += delta;
+                    break;
+                case "spirit":
+                case "spi":
+                    stats.Spirit += delta;
+                    break;
+                case "vitality":
+                case "vit":
+                    stats.Vitality += delta;
+                    break;
+                case "luck":
+                case "luk":
+                    stats.Luck += delta;
+                    break;
+            }
         }
 
         public override string ToString()
         {
-            return $"+ {EffectPower} {StatKey}";
+            return $"- {EffectPower} {StatKey}";
         }
     }
 }

--- a/Core/Inventory/Scripts/Effects/PlusStat.cs
+++ b/Core/Inventory/Scripts/Effects/PlusStat.cs
@@ -16,12 +16,64 @@ namespace ethra.V1
         }
         public void RemoveItemEffect()
         {
-            throw new System.NotImplementedException();
+            if (Owner is not IStats stats)
+            {
+                return;
+            }
+
+            ModifyStat(stats, -EffectPower);
         }
 
         public void ResolveItemEffect()
         {
-            throw new System.NotImplementedException();
+            if (Owner is not IStats stats)
+            {
+                return;
+            }
+
+            ModifyStat(stats, EffectPower);
+        }
+
+        private void ModifyStat(IStats stats, int delta)
+        {
+            switch (StatKey.ToLowerInvariant())
+            {
+                case "maxhp":
+                    stats.MaxHP += delta;
+                    break;
+                case "maxmana":
+                    stats.MaxMana += delta;
+                    break;
+                case "strength":
+                case "str":
+                    stats.Strength += delta;
+                    break;
+                case "dexterity":
+                case "dex":
+                    stats.Dexterity += delta;
+                    break;
+                case "intelligence":
+                case "int":
+                    stats.Intelligence += delta;
+                    break;
+                case "spirit":
+                case "spi":
+                    stats.Spirit += delta;
+                    break;
+                case "vitality":
+                case "vit":
+                    stats.Vitality += delta;
+                    break;
+                case "luck":
+                case "luk":
+                    stats.Luck += delta;
+                    break;
+            }
+        }
+
+        public override string ToString()
+        {
+            return $"+ {EffectPower} {StatKey}";
         }
     }
 }

--- a/Core/Inventory/Scripts/InventoryItem.cs
+++ b/Core/Inventory/Scripts/InventoryItem.cs
@@ -1,39 +1,60 @@
 using System.Collections.Generic;
-using System.Linq;
 using Godot;
 
 namespace ethra.V1
 {
     public abstract class InventoryItem : IInventoryItem, IResolveable
     {
-        private int _id;
-        private string _name;
-        private int _value;
-        private string description;
-        private string _rarity;
-        private List<ItemEffects> _effects;
-        private int _resolveOrder = 15;
-        private Entity _owner;
+        protected int _id;
+        protected string _name;
+        protected int _value;
+        protected string _description;
+        protected string _rarity;
+        protected string _category;
+        protected string _subtype;
+        protected int _maxStack = 99;
+        protected List<ItemEffects> _effects;
+        protected int _resolveOrder = 15;
+        protected Entity _owner;
 
         public int Id => _id;
         public string Name => _name;
         public int Value => _value;
-        public string Description => description;
+        public string Description => _description;
         public string Rarity => _rarity;
+        public string Category => _category;
+        public string Subtype => _subtype;
+        public int MaxStack => _maxStack;
         public List<ItemEffects> Effects => _effects;
         public Entity Owner => _owner;
 
         public int ResolveOrder => _resolveOrder;
 
+        protected InventoryItem()
+        {
+            _effects = new List<ItemEffects>();
+        }
 
+        protected InventoryItem(int id, string name, int value, string description, string rarity, List<ItemEffects> effects = null, string category = "", string subtype = "", int maxStack = 99)
+        {
+            _id = id;
+            _name = name;
+            _value = value;
+            _description = description;
+            _rarity = rarity;
+            _category = category;
+            _subtype = subtype;
+            _maxStack = maxStack > 0 ? maxStack : 99;
+            _effects = effects ?? new List<ItemEffects>();
+        }
 
         public ItemInfo GetInfo()
         {
-            string[] effectList = new string[12];
+            List<string> effectList = new List<string>();
 
-            foreach(ItemEffects effect in Effects)
+            foreach (ItemEffects effect in Effects)
             {
-                effectList.Append(effect.ToString());
+                effectList.Add(effect.ToString());
             }
             return new ItemInfo
             {
@@ -41,7 +62,7 @@ namespace ethra.V1
                 Value = Value.ToString(),
                 Description = Description,
                 Rarity = Rarity,
-                Effects = effectList
+                Effects = effectList.ToArray()
             };
         }
 
@@ -57,7 +78,18 @@ namespace ethra.V1
 
         public virtual void Use()
         {
-            GD.Print($"===Item Used=== : {Name} on {_owner.Name}");
+            string ownerName = _owner != null ? _owner.Name : "None";
+            GD.Print($"===Item Used=== : {Name} on {ownerName}");
+        }
+
+        public void SetOwner(Entity owner)
+        {
+            _owner = owner;
+
+            foreach (ItemEffects effect in _effects)
+            {
+                effect.SetOwner(owner);
+            }
         }
     }
 }

--- a/Core/Inventory/Scripts/InventorySave.cs
+++ b/Core/Inventory/Scripts/InventorySave.cs
@@ -1,10 +1,17 @@
-
-
+using System.Collections.Generic;
 
 namespace ethra.V1
 {
     public class InventorySave
     {
-        
+        public List<InventoryStackEntry> Items { get; set; } = new();
+        public Dictionary<string, int> EquippedArmorBySlot { get; set; } = new();
+        public Dictionary<string, int> EquippedWeaponBySlot { get; set; } = new();
+    }
+
+    public class InventoryStackEntry
+    {
+        public int ItemId { get; set; }
+        public int Quantity { get; set; }
     }
 }

--- a/Core/Inventory/Scripts/ItemEffects.cs
+++ b/Core/Inventory/Scripts/ItemEffects.cs
@@ -23,6 +23,11 @@ namespace ethra.V1
             _owner = owner;
         }
 
+       public void SetOwner(Entity owner)
+       {
+            _owner = owner;
+       }
+
         
     }
 }

--- a/Core/Inventory/Scripts/WeaponItem.cs
+++ b/Core/Inventory/Scripts/WeaponItem.cs
@@ -1,0 +1,75 @@
+using Godot;
+using System.Collections.Generic;
+
+namespace ethra.V1
+{
+    public class WeaponItem : InventoryItem
+    {
+        private bool _isEquipped;
+
+        public string WeaponSlot => "MainHand";
+        public bool IsEquipped => _isEquipped;
+
+        public WeaponItem(
+            int id,
+            string name,
+            int value,
+            string description,
+            string rarity,
+            int maxStack,
+            List<ItemEffects> effects = null)
+            : base(id, name, value, description, rarity, effects, category: "Weapon", subtype: "MainHand", maxStack: maxStack)
+        {
+        }
+
+        public void Equip()
+        {
+            if (_isEquipped)
+            {
+                return;
+            }
+
+            foreach (ItemEffects effect in Effects)
+            {
+                if (effect is IEffect itemEffect)
+                {
+                    itemEffect.ResolveItemEffect();
+                }
+            }
+
+            _isEquipped = true;
+            GD.Print($"Equipped weapon '{Name}' in slot '{WeaponSlot}'.");
+        }
+
+        public void Unequip()
+        {
+            if (!_isEquipped)
+            {
+                return;
+            }
+
+            foreach (ItemEffects effect in Effects)
+            {
+                if (effect is IEffect itemEffect)
+                {
+                    itemEffect.RemoveItemEffect();
+                }
+            }
+
+            _isEquipped = false;
+            GD.Print($"Unequipped weapon '{Name}' from slot '{WeaponSlot}'.");
+        }
+
+        public override void Use()
+        {
+            if (IsEquipped)
+            {
+                Unequip();
+            }
+            else
+            {
+                Equip();
+            }
+        }
+    }
+}

--- a/Core/Managers/GameManager.cs
+++ b/Core/Managers/GameManager.cs
@@ -64,12 +64,14 @@ namespace ethra.V1
 	[ExportGroup("Scene folder Path")]
 	[Export] public string SceneFolderLocation;
 
-	[ExportGroup("SQLite Connection Strings")]
+	[ExportGroup("Repository Data Sources")]
 
-	[ExportSubgroup("Dialog Table Connection")]
-	[Export] public string DialogConn;
-	[ExportSubgroup("Item Table Connection")]
-	[Export] public string ItemConn;
+	[ExportSubgroup("Dialog CSV")]
+	[Export] public string DialogCsvPath = string.Empty;
+	[ExportSubgroup("Item CSV")]
+	[Export] public string ItemCsvPath = "res://Core/Inventory/Data/items_seed.csv";
+	[ExportSubgroup("Item Effects CSV")]
+	[Export] public string ItemEffectsCsvPath = "res://Core/Inventory/Data/item_effects_seed.csv";
 
 	[ExportGroup("Player Exports")]
 		[ExportSubgroup("StateMachine")]
@@ -189,6 +191,7 @@ namespace ethra.V1
 			registerManager(_ui);
 
 			GetAllItems();
+			GetAllItemEffects();
 			GetAllDialog();
 			GetAllScenes();
 
@@ -207,7 +210,30 @@ namespace ethra.V1
 	public void GetAllItems()
 		{
 		// this will get called after all the manager's have been initialized and start loading all the game item refrences into the master repository
-		DB.FillSQLRepo(ItemConn);
+		if (string.IsNullOrWhiteSpace(ItemCsvPath))
+		{
+			GD.PushWarning("GetAllItems: ItemCsvPath is empty. Skipping item csv load.");
+			return;
+		}
+
+				DB.FillCsvRepo(ItemCsvPath, MasterRepository.RepoLoadType.Items, new[]
+						{
+							"id", "name", "category", "description", "rarity", "sell_value", "subtype", "max_stack"
+						});
+					}
+
+		public void GetAllItemEffects()
+		{
+			if (string.IsNullOrWhiteSpace(ItemEffectsCsvPath))
+			{
+				GD.PushWarning("GetAllItemEffects: ItemEffectsCsvPath is empty. Skipping item effects csv load.");
+				return;
+			}
+
+			DB.FillCsvRepo(ItemEffectsCsvPath, MasterRepository.RepoLoadType.ItemEffects, new[]
+				{
+					"item_id", "effect_type", "effect_stat", "effect_power"
+				});
 		}
 
 	public void GetAllScenes()
@@ -219,7 +245,13 @@ namespace ethra.V1
 		public void GetAllDialog()
 		{
 			// loads all the dialog trees into the master repository
-			DB.FillSQLRepo(DialogConn);
+			if (string.IsNullOrWhiteSpace(DialogCsvPath))
+			{
+				GD.PushWarning("GetAllDialog: DialogCsvPath is empty. Skipping dialog csv load.");
+				return;
+			}
+
+			DB.FillCsvRepo(DialogCsvPath, MasterRepository.RepoLoadType.Dialog);
 		}
 		#endregion
 
@@ -566,9 +598,9 @@ namespace ethra.V1
 		   _inventory.UseItem(id);
 		}
 
-		public void AddItem(int id)
+		public bool AddItem(int id)
 		{
-			_inventory.AddItem(id);
+			return _inventory.AddItem(id);
 		}
 
 		public void DropItem(int id)

--- a/Core/Managers/InventoryManager.cs
+++ b/Core/Managers/InventoryManager.cs
@@ -1,7 +1,6 @@
 using Godot;
 using System;
 using System.Collections.Generic;
-using System.Security.Cryptography.X509Certificates;
 
 namespace ethra.V1
 {
@@ -12,6 +11,8 @@ namespace ethra.V1
         /// <id, count>
         /// </summary>
         private Dictionary<int, int> _itemDict;
+        private Dictionary<string, int> _equippedArmorBySlot;
+        private Dictionary<string, int> _equippedWeaponBySlot;
         private int maxStack = 99;
         private readonly MasterRepository _db;
 
@@ -20,56 +21,110 @@ namespace ethra.V1
         public InventoryManager(MasterRepository db)
         {
             _db = db;
+            _itemDict = new Dictionary<int, int>();
+            _equippedArmorBySlot = new Dictionary<string, int>();
+            _equippedWeaponBySlot = new Dictionary<string, int>();
         }
 
 
-        public void AddItem(int id)
+        public bool AddItem(int id)
         {
+            InventoryItem itemData = _db.GetItemFromRepo(id);
+            if(itemData == null)
+            {
+                GD.Print($"Unable to add item to inventory. id:{id} not found in repo.");
+                return false;
+            }
+
+            int maxAllowed = itemData.MaxStack > 0 ? itemData.MaxStack : maxStack;
+
             if(_itemDict.TryGetValue(id, out int count))
             {
-                if(count + 1 < maxStack)
+                if(count + 1 <= maxAllowed)
                 {
                      _itemDict[id] = count + 1;
+                     return true;
                 }
                 else
                 {
-                    GD.Print("Unable to add item to inventory. max stack exceeded.");
-                    DropItem(id);
+                    GD.Print($"Unable to add item to inventory. max stack exceeded for id:{id}.");
+                    return false;
                 }
                
             }
             else
             {
                 _itemDict.Add(id, 1);
+                return true;
             }
         }
 
         public object CaptureSnapshot()
         {
-            List<int> items = new List<int>();
-            foreach(int id in _itemDict.Keys)
+            InventorySave save = new InventorySave();
+
+            foreach(var kvp in _itemDict)
             {
-                int count = _itemDict[id];
-                for(int i =0; i < count; i++)
+                if (kvp.Value <= 0)
                 {
-                    items.Add(id);
+                    continue;
                 }
+
+                save.Items.Add(new InventoryStackEntry
+                {
+                    ItemId = kvp.Key,
+                    Quantity = kvp.Value
+                });
             }
-            return items.ToArray();
+
+            save.EquippedArmorBySlot = new Dictionary<string, int>(_equippedArmorBySlot);
+            save.EquippedWeaponBySlot = new Dictionary<string, int>(_equippedWeaponBySlot);
+            return save;
         }
 
         public void DropItem(int id)
         {
-            throw new NotImplementedException();
-            // this will require a spawner manager or something.
+            if(!_itemDict.TryGetValue(id, out int currentCount) || currentCount <= 0)
+            {
+                GD.Print($"DropItem: item id:{id} is not in inventory.");
+                return;
+            }
+
+            if (currentCount == 1)
+            {
+                _itemDict.Remove(id);
+                UnequipItemIfNeeded(id);
+            }
+            else
+            {
+                _itemDict[id] = currentCount - 1;
+            }
+
+            GD.Print($"Dropped item id:{id}. Remaining quantity: {_itemDict.GetValueOrDefault(id, 0)}");
         }
 
 
         public void RestoreSnapshot(object snapshot)
         {
-            if(snapshot is List<int> items)
+            ClearAllEquipment();
+            _itemDict.Clear();
+
+            if(snapshot is InventorySave inventorySave)
             {
-                foreach(int i in items)
+                RestoreFromInventorySave(inventorySave);
+                return;
+            }
+
+            if(snapshot is List<int> listItems)
+            {
+                foreach(int i in listItems)
+                {
+                    AddItem(i);
+                }
+            }
+            else if(snapshot is int[] arrayItems)
+            {
+                foreach(int i in arrayItems)
                 {
                     AddItem(i);
                 }
@@ -78,11 +133,41 @@ namespace ethra.V1
 
         public void UseItem(int id)
         {
-            IInventoryItem itemToUse = _db.GetItemFromRepo(id);
+            if(!_itemDict.TryGetValue(id, out int count) || count <= 0)
+            {
+                GD.Print($"Unable to use item. id:{id} is not in inventory.");
+                return;
+            }
+
+            InventoryItem itemToUse = _db.GetItemFromRepo(id);
 
             if(itemToUse != null)
             {
+                Player player = GameManager.Instance?.GetPlayer();
+                if (player != null)
+                {
+                    itemToUse.SetOwner(player);
+                }
+
+                if (itemToUse is ArmorItem armor)
+                {
+                    ToggleArmorEquip(armor);
+                    return;
+                }
+
+                if (itemToUse is WeaponItem weapon)
+                {
+                    ToggleWeaponEquip(weapon);
+                    return;
+                }
+
                 itemToUse.Use();
+
+                if (itemToUse is ConsumeItem)
+                {
+                    int remaining = ConsumeOne(id);
+                    GD.Print($"Consumed item id:{id}. Remaining quantity: {remaining}");
+                }
             }
             else
             {
@@ -94,7 +179,245 @@ namespace ethra.V1
             //then set the UI as dirty forcing it to update.
         }
 
+        private void ToggleArmorEquip(ArmorItem armor)
+        {
+            string slot = string.IsNullOrWhiteSpace(armor.ArmorSlot) ? "Armor" : armor.ArmorSlot;
+
+            if (_equippedArmorBySlot.TryGetValue(slot, out int equippedId))
+            {
+                if (equippedId == armor.Id)
+                {
+                    armor.Unequip();
+                    _equippedArmorBySlot.Remove(slot);
+                    return;
+                }
+
+                InventoryItem currentlyEquipped = _db.GetItemFromRepo(equippedId);
+                if (currentlyEquipped is ArmorItem equippedArmor)
+                {
+                    equippedArmor.Unequip();
+                }
+            }
+
+            armor.Equip();
+            _equippedArmorBySlot[slot] = armor.Id;
+        }
+
+        private void ToggleWeaponEquip(WeaponItem weapon)
+        {
+            string slot = weapon.WeaponSlot;
+
+            if (_equippedWeaponBySlot.TryGetValue(slot, out int equippedId))
+            {
+                if (equippedId == weapon.Id)
+                {
+                    weapon.Unequip();
+                    _equippedWeaponBySlot.Remove(slot);
+                    return;
+                }
+
+                InventoryItem currentlyEquipped = _db.GetItemFromRepo(equippedId);
+                if (currentlyEquipped is WeaponItem equippedWeapon)
+                {
+                    equippedWeapon.Unequip();
+                }
+            }
+
+            weapon.Equip();
+            _equippedWeaponBySlot[slot] = weapon.Id;
+        }
+
+        private int ConsumeOne(int id)
+        {
+            if(!_itemDict.TryGetValue(id, out int currentCount) || currentCount <= 0)
+            {
+                return 0;
+            }
+
+            if(currentCount == 1)
+            {
+                _itemDict.Remove(id);
+                return 0;
+            }
+            else
+            {
+                int remaining = currentCount - 1;
+                _itemDict[id] = remaining;
+                return remaining;
+            }
+        }
+
+        private void RestoreFromInventorySave(InventorySave save)
+        {
+            if (save?.Items != null)
+            {
+                foreach (InventoryStackEntry entry in save.Items)
+                {
+                    if (entry == null || entry.Quantity <= 0)
+                    {
+                        continue;
+                    }
+
+                    for (int i = 0; i < entry.Quantity; i++)
+                    {
+                        AddItem(entry.ItemId);
+                    }
+                }
+            }
+
+            if (save?.EquippedArmorBySlot != null)
+            {
+                foreach (var kvp in save.EquippedArmorBySlot)
+                {
+                    if (!_itemDict.TryGetValue(kvp.Value, out int qty) || qty <= 0)
+                    {
+                        continue;
+                    }
+
+                    InventoryItem item = _db.GetItemFromRepo(kvp.Value);
+                    if (item is not ArmorItem armor)
+                    {
+                        continue;
+                    }
+
+                    Player player = GameManager.Instance?.GetPlayer();
+                    if (player != null)
+                    {
+                        armor.SetOwner(player);
+                    }
+
+                    armor.Equip();
+                    _equippedArmorBySlot[kvp.Key] = kvp.Value;
+                }
+            }
+
+            if (save?.EquippedWeaponBySlot != null)
+            {
+                foreach (var kvp in save.EquippedWeaponBySlot)
+                {
+                    if (!_itemDict.TryGetValue(kvp.Value, out int qty) || qty <= 0)
+                    {
+                        continue;
+                    }
+
+                    InventoryItem item = _db.GetItemFromRepo(kvp.Value);
+                    if (item is not WeaponItem weapon)
+                    {
+                        continue;
+                    }
+
+                    Player player = GameManager.Instance?.GetPlayer();
+                    if (player != null)
+                    {
+                        weapon.SetOwner(player);
+                    }
+
+                    weapon.Equip();
+                    _equippedWeaponBySlot[kvp.Key] = kvp.Value;
+                }
+            }
+        }
+
+        private void UnequipItemIfNeeded(int id)
+        {
+            InventoryItem item = _db.GetItemFromRepo(id);
+
+            if (item is ArmorItem armor)
+            {
+                armor.Unequip();
+                string foundSlot = null;
+                foreach (var slot in _equippedArmorBySlot)
+                {
+                    if (slot.Value == id)
+                    {
+                        foundSlot = slot.Key;
+                        break;
+                    }
+                }
+
+                if (!string.IsNullOrWhiteSpace(foundSlot))
+                {
+                    _equippedArmorBySlot.Remove(foundSlot);
+                }
+            }
+            else if (item is WeaponItem weapon)
+            {
+                weapon.Unequip();
+                string foundSlot = null;
+                foreach (var slot in _equippedWeaponBySlot)
+                {
+                    if (slot.Value == id)
+                    {
+                        foundSlot = slot.Key;
+                        break;
+                    }
+                }
+
+                if (!string.IsNullOrWhiteSpace(foundSlot))
+                {
+                    _equippedWeaponBySlot.Remove(foundSlot);
+                }
+            }
+        }
+
+        private void ClearAllEquipment()
+        {
+            foreach (var kvp in _equippedArmorBySlot)
+            {
+                if (_db.GetItemFromRepo(kvp.Value) is ArmorItem armor)
+                {
+                    armor.Unequip();
+                }
+            }
+
+            foreach (var kvp in _equippedWeaponBySlot)
+            {
+                if (_db.GetItemFromRepo(kvp.Value) is WeaponItem weapon)
+                {
+                    weapon.Unequip();
+                }
+            }
+
+            _equippedArmorBySlot.Clear();
+            _equippedWeaponBySlot.Clear();
+        }
+
+        public IReadOnlyDictionary<int, int> GetItemCounts()
+        {
+            return _itemDict;
+        }
+
+        public IReadOnlyDictionary<string, int> GetEquippedArmorSlots()
+        {
+            return _equippedArmorBySlot;
+        }
+
+        public IReadOnlyDictionary<string, int> GetEquippedWeaponSlots()
+        {
+            return _equippedWeaponBySlot;
+        }
+
+        public bool IsEquipped(int itemId)
+        {
+            foreach (var kvp in _equippedArmorBySlot)
+            {
+                if (kvp.Value == itemId)
+                {
+                    return true;
+                }
+            }
+
+            foreach (var kvp in _equippedWeaponBySlot)
+            {
+                if (kvp.Value == itemId)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
 
     }
 }
-

--- a/Core/Managers/MasterRepository.cs
+++ b/Core/Managers/MasterRepository.cs
@@ -1,28 +1,32 @@
-
-
-
-
 using System;
 using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
 using Godot;
 
 namespace ethra.V1
 {
 	public partial class MasterRepository
-{
-	//=========== fields and Properties ==================//
-	// this scene repo is for game levels
-	private Dictionary<string, PackedScene> _sceneRepo;
+	{
+		public enum RepoLoadType
+		{
+			Items,
+			ItemEffects,
+			Dialog,
+			Entity
+		}
 
-	private Dictionary<int, InventoryItem> _itemRepo;
+		//=========== fields and Properties ==================//
+		// this scene repo is for game levels
+		private Dictionary<string, PackedScene> _sceneRepo;
 
+		private Dictionary<int, InventoryItem> _itemRepo;
 
 		public MasterRepository()
 		{
 			_sceneRepo = new Dictionary<string, PackedScene>();
 			_itemRepo = new Dictionary<int, InventoryItem>();
 		}
-
 
 		// dialog repo is a dictionary with and int for id and a DialogNode class object <int, DialogNode>
 
@@ -34,7 +38,7 @@ namespace ethra.V1
 		// ============ public facing methods =================//
 
 		public void FillSceneRepo(string rootPath)
-	{
+		{
 			if (string.IsNullOrWhiteSpace(rootPath))
 			{
 				GD.PushError("FillSceneRepo: rootPath is empty.");
@@ -55,6 +59,67 @@ namespace ethra.V1
 			GD.Print($"FillSceneRepo: loaded {added} scenes from {rootPath}");
 		}
 
+		public void FillSQLRepo(string path)
+		{
+			// the item, dialog and Entity objects will be stored in an SQLite DB the path will determine which table to pull form
+			// likely use a switch statement that will parse the response, create the object type and add it to the proper dictionary
+		}
+
+		public void FillCsvRepo(string path, RepoLoadType loadType, IEnumerable<string> requiredHeaders = null)
+		{
+			if (string.IsNullOrWhiteSpace(path))
+			{
+				GD.PushError("FillCsvRepo: csv path is empty.");
+				return;
+			}
+
+			if (!FileAccess.FileExists(path))
+			{
+				GD.PushError($"FillCsvRepo: file does not exist: {path}");
+				return;
+			}
+
+			var rows = ReadCsvRows(path);
+			if (rows.Count == 0)
+			{
+				GD.PushError($"FillCsvRepo: no rows found in csv: {path}");
+				return;
+			}
+
+			var headers = rows[0];
+			if (!ValidateHeaders(headers, requiredHeaders))
+			{
+				GD.PushError($"FillCsvRepo: required headers missing for {loadType} csv: {path}");
+				return;
+			}
+
+				switch (loadType)
+				{
+					case RepoLoadType.Items:
+						LoadItemsFromCsv(headers, rows, path);
+						break;
+					case RepoLoadType.ItemEffects:
+						LoadItemEffectsFromCsv(headers, rows, path);
+						break;
+					case RepoLoadType.Dialog:
+						GD.Print($"FillCsvRepo: dialog loader not implemented yet. source={path}");
+						break;
+				case RepoLoadType.Entity:
+					GD.Print($"FillCsvRepo: entity loader not implemented yet. source={path}");
+					break;
+			}
+		}
+
+		public PackedScene GetSceneFromRepo(string sceneName)
+		{
+			if (string.IsNullOrWhiteSpace(sceneName)) return null;
+			return _sceneRepo.TryGetValue(sceneName, out var data) ? data : null;
+		}
+
+		public InventoryItem GetItemFromRepo(int id)
+		{
+			return _itemRepo.TryGetValue(id, out var item) ? item : null;
+		}
 
 		private void ScanDirRecursive(string dirPath, ref int added)
 		{
@@ -101,25 +166,288 @@ namespace ethra.V1
 			dir.ListDirEnd();
 		}
 
-		public void FillSQLRepo(string path)
-	{
-		// the item, dialog and Entity objects will be stored in an SQLite DB the path will determine which table to pull form
-		// likely use a switch statement that will parse the response, create the object type and add it to the proper dictionary
-
-	}
-	
-	public PackedScene GetSceneFromRepo(string sceneName)
+		private bool ValidateHeaders(IReadOnlyList<string> headers, IEnumerable<string> requiredHeaders)
 		{
-			if (string.IsNullOrWhiteSpace(sceneName)) return null;
-			return _sceneRepo.TryGetValue(sceneName, out var data) ? data : null;
+			if (requiredHeaders == null)
+			{
+				return true;
+			}
 
+			HashSet<string> headerSet = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+			foreach (string header in headers)
+			{
+				headerSet.Add(header.Trim());
+			}
+
+			foreach (string required in requiredHeaders)
+			{
+				if (!headerSet.Contains(required))
+				{
+					GD.PushError($"FillCsvRepo: missing required header '{required}'.");
+					return false;
+				}
+			}
+
+			return true;
 		}
-	
-	public InventoryItem GetItemFromRepo(int id)
+
+		private List<string[]> ReadCsvRows(string path)
 		{
-			return _itemRepo.TryGetValue(id, out var item) ? item : null;
+			List<string[]> rows = new List<string[]>();
+
+			using FileAccess file = FileAccess.Open(path, FileAccess.ModeFlags.Read);
+			if (file == null)
+			{
+				GD.PushError($"FillCsvRepo: unable to open file {path}");
+				return rows;
+			}
+
+			while (!file.EofReached())
+			{
+				string line = file.GetLine();
+				if (string.IsNullOrWhiteSpace(line))
+				{
+					continue;
+				}
+
+				rows.Add(ParseCsvLine(line));
+			}
+
+			return rows;
 		}
 
-	   
+		private string[] ParseCsvLine(string line)
+		{
+			List<string> values = new List<string>();
+			StringBuilder token = new StringBuilder();
+			bool inQuotes = false;
+
+			for (int i = 0; i < line.Length; i++)
+			{
+				char c = line[i];
+
+				if (c == '"')
+				{
+					bool isEscapedQuote = inQuotes && i + 1 < line.Length && line[i + 1] == '"';
+					if (isEscapedQuote)
+					{
+						token.Append('"');
+						i++;
+					}
+					else
+					{
+						inQuotes = !inQuotes;
+					}
+					continue;
+				}
+
+				if (c == ',' && !inQuotes)
+				{
+					values.Add(token.ToString().Trim());
+					token.Clear();
+					continue;
+				}
+
+				token.Append(c);
+			}
+
+			values.Add(token.ToString().Trim());
+			return values.ToArray();
+		}
+
+		private void LoadItemsFromCsv(IReadOnlyList<string> headers, IReadOnlyList<string[]> rows, string sourcePath)
+		{
+			Dictionary<string, int> headerIndex = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+			for (int i = 0; i < headers.Count; i++)
+			{
+				headerIndex[headers[i].Trim()] = i;
+			}
+
+			_itemRepo.Clear();
+			int loaded = 0;
+			int skipped = 0;
+
+			for (int rowIndex = 1; rowIndex < rows.Count; rowIndex++)
+			{
+				string[] row = rows[rowIndex];
+
+				if (!TryGetInt(headerIndex, row, "id", out int id))
+				{
+					skipped++;
+					GD.PushError($"LoadItemsFromCsv: row {rowIndex + 1} missing/invalid id.");
+					continue;
+				}
+
+				string name = GetString(headerIndex, row, "name");
+				if (string.IsNullOrWhiteSpace(name))
+				{
+					skipped++;
+					GD.PushError($"LoadItemsFromCsv: row {rowIndex + 1} has empty name for id {id}.");
+					continue;
+				}
+
+					string description = GetString(headerIndex, row, "description");
+					string rarity = GetString(headerIndex, row, "rarity");
+						string category = GetString(headerIndex, row, "category");
+						string subtype = GetString(headerIndex, row, "subtype");
+						int value = GetIntOrDefault(headerIndex, row, "sell_value", 0);
+						int maxStack = GetIntOrDefault(headerIndex, row, "max_stack", 99);
+
+					if (_itemRepo.ContainsKey(id))
+					{
+					skipped++;
+					GD.PushError($"LoadItemsFromCsv: duplicate item id {id} at row {rowIndex + 1}.");
+					continue;
+				}
+
+					InventoryItem item = CreateInventoryItem(
+						id,
+						name,
+						value,
+								description,
+								rarity,
+								category,
+								subtype,
+								maxStack,
+								new List<ItemEffects>());
+							_itemRepo.Add(id, item);
+							loaded++;
+						}
+
+				GD.Print($"LoadItemsFromCsv: loaded={loaded} skipped={skipped} source={sourcePath}");
+			}
+
+		private InventoryItem CreateInventoryItem(
+				int id,
+				string name,
+				int value,
+				string description,
+				string rarity,
+				string category,
+				string subtype,
+				int maxStack,
+				List<ItemEffects> effects)
+			{
+				if (string.Equals(category, "Crafting", StringComparison.OrdinalIgnoreCase))
+				{
+					return new CraftingItem(id, name, value, description, rarity, subtype, maxStack, effects);
+				}
+
+				if (string.Equals(category, "Consumable", StringComparison.OrdinalIgnoreCase))
+				{
+					return new ConsumeItem(id, name, value, description, rarity, subtype, maxStack, effects);
+				}
+
+				if (string.Equals(category, "Armor", StringComparison.OrdinalIgnoreCase))
+				{
+					return new ArmorItem(id, name, value, description, rarity, subtype, maxStack, effects);
+				}
+
+				if (string.Equals(category, "Weapon", StringComparison.OrdinalIgnoreCase))
+				{
+					return new WeaponItem(id, name, value, description, rarity, maxStack, effects);
+				}
+
+				return new BasicInventoryItem(id, name, value, description, rarity, effects, category: category, subtype: subtype, maxStack: maxStack);
+			}
+
+		private void LoadItemEffectsFromCsv(IReadOnlyList<string> headers, IReadOnlyList<string[]> rows, string sourcePath)
+		{
+			Dictionary<string, int> headerIndex = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+			for (int i = 0; i < headers.Count; i++)
+			{
+				headerIndex[headers[i].Trim()] = i;
+			}
+
+			int loaded = 0;
+			int skipped = 0;
+
+			for (int rowIndex = 1; rowIndex < rows.Count; rowIndex++)
+			{
+				string[] row = rows[rowIndex];
+				if (!TryGetInt(headerIndex, row, "item_id", out int itemId))
+				{
+					skipped++;
+					GD.PushError($"LoadItemEffectsFromCsv: row {rowIndex + 1} missing/invalid item_id.");
+					continue;
+				}
+
+				if (!_itemRepo.TryGetValue(itemId, out InventoryItem item))
+				{
+					skipped++;
+					GD.PushError($"LoadItemEffectsFromCsv: item {itemId} not found in item repo.");
+					continue;
+				}
+
+				string effectType = GetString(headerIndex, row, "effect_type");
+				string effectStat = GetString(headerIndex, row, "effect_stat");
+				int effectPower = GetIntOrDefault(headerIndex, row, "effect_power", 0);
+
+				ItemEffects effect = BuildEffect(effectType, effectStat, effectPower);
+				if (effect == null)
+				{
+					skipped++;
+					continue;
+				}
+
+				item.Effects.Add(effect);
+				loaded++;
+			}
+
+			GD.Print($"LoadItemEffectsFromCsv: loaded={loaded} skipped={skipped} source={sourcePath}");
+		}
+
+		private ItemEffects BuildEffect(string effectType, string effectStat, int effectPower)
+		{
+			if (string.IsNullOrWhiteSpace(effectType) || string.IsNullOrWhiteSpace(effectStat) || effectPower == 0)
+			{
+				return null;
+			}
+
+			string effectName = $"{effectType}:{effectStat}";
+
+			if (string.Equals(effectType, "plus", StringComparison.OrdinalIgnoreCase))
+			{
+				return new PlusStat(effectStat, effectPower, effectName, null);
+			}
+			if (string.Equals(effectType, "minus", StringComparison.OrdinalIgnoreCase))
+			{
+				return new MinusStat(effectStat, effectPower, effectName, null);
+			}
+
+			return null;
+		}
+
+		private string GetString(Dictionary<string, int> headerIndex, string[] row, string headerName)
+		{
+			if (!headerIndex.TryGetValue(headerName, out int index))
+			{
+				return string.Empty;
+			}
+
+			if (index < 0 || index >= row.Length)
+			{
+				return string.Empty;
+			}
+
+			return row[index].Trim();
+		}
+
+		private bool TryGetInt(Dictionary<string, int> headerIndex, string[] row, string headerName, out int value)
+		{
+			value = 0;
+			string raw = GetString(headerIndex, row, headerName);
+			return int.TryParse(raw, NumberStyles.Integer, CultureInfo.InvariantCulture, out value);
+		}
+
+		private int GetIntOrDefault(Dictionary<string, int> headerIndex, string[] row, string headerName, int defaultValue)
+		{
+			if (TryGetInt(headerIndex, row, headerName, out int parsed))
+			{
+				return parsed;
+			}
+
+			return defaultValue;
+		}
 	}
 }

--- a/Core/Nodes/Interactable/ItemPickup.cs
+++ b/Core/Nodes/Interactable/ItemPickup.cs
@@ -1,0 +1,99 @@
+using Godot;
+
+namespace ethra.V1
+{
+    public partial class ItemPickup : Area2D
+    {
+        [Export] public int ItemId { get; set; }
+        [Export] public int Quantity { get; set; } = 1;
+        [Export] public bool RequireInteract { get; set; } = true;
+        [Export] public NodePath SpritePath { get; set; } = "Sprite2D";
+        [Export] public Texture2D PickupTexture { get; set; }
+
+        private bool _playerInside;
+        private Sprite2D _sprite;
+
+        public override void _Ready()
+        {
+            _sprite = GetNodeOrNull<Sprite2D>(SpritePath);
+            if (_sprite == null)
+            {
+                GD.PushWarning($"ItemPickup: Sprite2D not found at path '{SpritePath}'.");
+            }
+            else if (PickupTexture != null)
+            {
+                _sprite.Texture = PickupTexture;
+            }
+
+            BodyEntered += OnBodyEntered;
+            BodyExited += OnBodyExited;
+        }
+
+        public override void _Process(double delta)
+        {
+            if (!RequireInteract || !_playerInside)
+            {
+                return;
+            }
+
+            if (Input.IsActionJustPressed("Interact"))
+            {
+                TryPickup();
+            }
+        }
+
+        private void OnBodyEntered(Node2D body)
+        {
+            if (body is not PlayerNode)
+            {
+                return;
+            }
+
+            _playerInside = true;
+            if (!RequireInteract)
+            {
+                TryPickup();
+            }
+        }
+
+        private void OnBodyExited(Node2D body)
+        {
+            if (body is PlayerNode)
+            {
+                _playerInside = false;
+            }
+        }
+
+        private void TryPickup()
+        {
+            var gm = GameManager.Instance;
+            if (gm == null)
+            {
+                GD.PushError("ItemPickup: GameManager.Instance was null.");
+                return;
+            }
+
+            int attempts = Quantity > 0 ? Quantity : 1;
+            int added = 0;
+
+            for (int i = 0; i < attempts; i++)
+            {
+                if (!gm.AddItem(ItemId))
+                {
+                    break;
+                }
+
+                added++;
+            }
+
+            if (added == attempts)
+            {
+                QueueFree();
+            }
+            else
+            {
+                GD.Print($"ItemPickup: pickup incomplete for item {ItemId}. added={added}/{attempts}");
+            }
+        }
+    }
+}

--- a/Core/UI/Scripts/InventorySlotView.cs
+++ b/Core/UI/Scripts/InventorySlotView.cs
@@ -1,0 +1,95 @@
+using System;
+using Godot;
+
+namespace ethra.V1
+{
+    public partial class InventorySlotView : Button
+    {
+        [Signal]
+        public delegate void ClickedEventHandler(int itemId);
+
+        private TextureRect _icon;
+        private Label _countLabel;
+        private CanvasItem _countContainer;
+        private TextureRect _selector;
+
+        public int ItemId { get; private set; } = -1;
+
+        public override void _Ready()
+        {
+            _icon = GetNodeOrNull<TextureRect>("Icon");
+            _countContainer = GetNodeOrNull<CanvasItem>("Panel");
+            _countLabel = GetNodeOrNull<Label>("Panel/Label");
+            _selector = GetNodeOrNull<TextureRect>("Selector");
+
+            Pressed += OnPressed;
+            SetEmpty();
+        }
+
+        public void SetItem(int itemId, int count, Texture2D icon = null)
+        {
+            ItemId = itemId;
+            Disabled = false;
+
+            if (_icon != null)
+            {
+                _icon.Texture = icon;
+                _icon.Visible = icon != null;
+            }
+
+            if (_countLabel != null)
+            {
+                _countLabel.Text = count.ToString();
+            }
+
+            if (_countContainer != null)
+            {
+                _countContainer.Visible = count > 1;
+            }
+
+            SetEquipped(false);
+        }
+
+        public void SetEmpty()
+        {
+            ItemId = -1;
+            Disabled = true;
+
+            if (_icon != null)
+            {
+                _icon.Texture = null;
+                _icon.Visible = false;
+            }
+
+            if (_countLabel != null)
+            {
+                _countLabel.Text = string.Empty;
+            }
+
+            if (_countContainer != null)
+            {
+                _countContainer.Visible = false;
+            }
+
+            SetEquipped(false);
+        }
+
+        public void SetEquipped(bool equipped)
+        {
+            if (_selector != null)
+            {
+                _selector.Visible = equipped;
+            }
+        }
+
+        private void OnPressed()
+        {
+            if (ItemId <= 0)
+            {
+                return;
+            }
+
+            EmitSignal(SignalName.Clicked, ItemId);
+        }
+    }
+}

--- a/Core/UI/Scripts/PlayerMenu.cs
+++ b/Core/UI/Scripts/PlayerMenu.cs
@@ -1,0 +1,162 @@
+using System.Collections.Generic;
+using Godot;
+
+namespace ethra.V1
+{
+    public partial class PlayerMenu : Control, IUIRefresh
+    {
+        [Export] public NodePath InventoryGridPath { get; set; } = "NinePatchRect/VBoxContainer/Inventory/VBoxContainer2/Inventory";
+        [Export] public NodePath WeaponEquipPath { get; set; } = "NinePatchRect/VBoxContainer/Inventory/VBoxContainer/PlayerView/HBoxContainer/PlayerEquip/WeaponEquip";
+        [Export] public NodePath ArmorEquipPath { get; set; } = "NinePatchRect/VBoxContainer/Inventory/VBoxContainer/PlayerView/HBoxContainer/PlayerEquip/ArmorEquip";
+
+        public bool needsRefresh { get; set; } = true;
+
+        private readonly List<InventorySlotView> _inventorySlots = new();
+        private InventorySlotView _weaponSlot;
+        private InventorySlotView _armorSlot;
+
+        public override void _Ready()
+        {
+            CacheSlots();
+            BindSlots();
+
+            GameManager.Instance?.UI?.Register(this);
+            needsRefresh = true;
+        }
+
+        public void Refresh()
+        {
+            InventoryManager inventory = GameManager.Instance?.Inventory;
+            MasterRepository repo = GameManager.Instance?.DB;
+
+            if (inventory == null || repo == null)
+            {
+                needsRefresh = false;
+                return;
+            }
+
+            foreach (InventorySlotView slot in _inventorySlots)
+            {
+                slot.SetEmpty();
+            }
+
+            if (_weaponSlot != null)
+            {
+                _weaponSlot.SetEmpty();
+            }
+
+            if (_armorSlot != null)
+            {
+                _armorSlot.SetEmpty();
+            }
+
+            int slotIndex = 0;
+            foreach (KeyValuePair<int, int> stack in inventory.GetItemCounts())
+            {
+                if (slotIndex >= _inventorySlots.Count)
+                {
+                    break;
+                }
+
+                InventoryItem itemData = repo.GetItemFromRepo(stack.Key);
+                if (itemData == null || stack.Value <= 0)
+                {
+                    continue;
+                }
+
+                InventorySlotView slot = _inventorySlots[slotIndex++];
+                slot.SetItem(itemData.Id, stack.Value);
+                slot.SetEquipped(inventory.IsEquipped(itemData.Id));
+            }
+
+            PopulateEquipSlots(inventory, repo);
+            needsRefresh = false;
+        }
+
+        private void CacheSlots()
+        {
+            _inventorySlots.Clear();
+
+            GridContainer grid = GetNodeOrNull<GridContainer>(InventoryGridPath);
+            if (grid == null)
+            {
+                GD.PushError($"PlayerMenu: Inventory grid not found at '{InventoryGridPath}'.");
+                return;
+            }
+
+            foreach (Node child in grid.GetChildren())
+            {
+                if (child is InventorySlotView slot)
+                {
+                    _inventorySlots.Add(slot);
+                }
+            }
+
+            _weaponSlot = GetNodeOrNull<InventorySlotView>(WeaponEquipPath);
+            _armorSlot = GetNodeOrNull<InventorySlotView>(ArmorEquipPath);
+        }
+
+        private void BindSlots()
+        {
+            foreach (InventorySlotView slot in _inventorySlots)
+            {
+                slot.Clicked += OnSlotClicked;
+            }
+
+            if (_weaponSlot != null)
+            {
+                _weaponSlot.Clicked += OnSlotClicked;
+            }
+
+            if (_armorSlot != null)
+            {
+                _armorSlot.Clicked += OnSlotClicked;
+            }
+        }
+
+        private void PopulateEquipSlots(InventoryManager inventory, MasterRepository repo)
+        {
+            foreach (KeyValuePair<string, int> weapon in inventory.GetEquippedWeaponSlots())
+            {
+                if (_weaponSlot == null)
+                {
+                    continue;
+                }
+
+                InventoryItem item = repo.GetItemFromRepo(weapon.Value);
+                if (item != null)
+                {
+                    _weaponSlot.SetItem(item.Id, 1);
+                    _weaponSlot.SetEquipped(true);
+                }
+            }
+
+            foreach (KeyValuePair<string, int> armor in inventory.GetEquippedArmorSlots())
+            {
+                if (_armorSlot == null)
+                {
+                    continue;
+                }
+
+                InventoryItem item = repo.GetItemFromRepo(armor.Value);
+                if (item != null)
+                {
+                    _armorSlot.SetItem(item.Id, 1);
+                    _armorSlot.SetEquipped(true);
+                    break;
+                }
+            }
+        }
+
+        private void OnSlotClicked(int itemId)
+        {
+            if (itemId <= 0)
+            {
+                return;
+            }
+
+            GameManager.Instance?.UseItem(itemId);
+            needsRefresh = true;
+        }
+    }
+}

--- a/PackedScenes/EthraV1/Core/Scripts/UIRoot.cs
+++ b/PackedScenes/EthraV1/Core/Scripts/UIRoot.cs
@@ -5,9 +5,11 @@ public partial class UIRoot : CanvasLayer
 {
 	 	[Export] public NodePath HudPath { get; set; } = "Hud";
 		[Export] public NodePath MainMenuPath { get; set; } = "Menus/MainMenu";
+		[Export] public NodePath PlayerMenuPath { get; set; } = "Hud/PlayerUi";
 
 		public Control Hud => GetNodeOrNull<Control>(HudPath);
 		public Control MainMenu => GetNodeOrNull<Control>(MainMenuPath);
+		public Control PlayerMenu => GetNodeOrNull<Control>(PlayerMenuPath);
 
 		public void ShowHud(bool show) => SetVisibleSafe(Hud, show);
 		public void ShowMainMenu(bool show) => SetVisibleSafe(MainMenu, show);
@@ -16,12 +18,37 @@ public partial class UIRoot : CanvasLayer
 		{
 			ShowHud(true);
 			ShowMainMenu(false);
+			ShowPlayerMenu(false);
 		}
 
 		public void ShowOnlyMainMenu()
 		{
 			ShowHud(false);
 			ShowMainMenu(true);
+			ShowPlayerMenu(false);
+		}
+
+		public void ShowPlayerMenu(bool show) => SetVisibleSafe(PlayerMenu, show);
+
+		public void TogglePlayerMenu()
+		{
+			Control menu = PlayerMenu;
+			if (menu == null)
+			{
+				GD.PushError("UIRoot: PlayerMenu node not found (check PlayerMenuPath).");
+				return;
+			}
+
+			menu.Visible = !menu.Visible;
+		}
+
+		public override void _UnhandledInput(InputEvent @event)
+		{
+			if (@event.IsActionPressed("Inventory_Toggle"))
+			{
+				TogglePlayerMenu();
+				GetViewport().SetInputAsHandled();
+			}
 		}
 
 		private static void SetVisibleSafe(CanvasItem node, bool visible)

--- a/PackedScenes/EthraV1/Core/UI/MasterNode.tscn
+++ b/PackedScenes/EthraV1/Core/UI/MasterNode.tscn
@@ -1,6 +1,7 @@
-[gd_scene load_steps=3 format=3 uid="uid://r5ws7i7wpgqr"]
+[gd_scene load_steps=4 format=3 uid="uid://r5ws7i7wpgqr"]
 
 [ext_resource type="Script" uid="uid://gfyujpg5x2v" path="res://PackedScenes/EthraV1/Core/Scripts/UIRoot.cs" id="1_u0jot"]
+[ext_resource type="PackedScene" uid="uid://dblf2lc3y1xu1" path="res://PackedScenes/UI/PlayerUI.tscn" id="2_6yhy2"]
 [ext_resource type="PackedScene" uid="uid://dc4iix4f1il4d" path="res://PackedScenes/EthraV1/Core/UI/MainMenu.tscn" id="4_bofv1"]
 
 [node name="MasterNode" type="Node2D"]
@@ -18,6 +19,10 @@ anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
+
+[node name="PlayerUi" parent="UI/Hud" instance=ExtResource("2_6yhy2")]
+visible = false
+layout_mode = 1
 
 [node name="Menus" type="Control" parent="UI"]
 layout_mode = 3

--- a/PackedScenes/EthraV1/Core/UI/inventory_slot.tscn
+++ b/PackedScenes/EthraV1/Core/UI/inventory_slot.tscn
@@ -1,9 +1,10 @@
-[gd_scene load_steps=7 format=3 uid="uid://ckmusyefdjgen"]
+[gd_scene load_steps=8 format=3 uid="uid://ckmusyefdjgen"]
 
 [ext_resource type="Texture2D" uid="uid://d0tt1kw0iosf6" path="res://ArtAssets/UI/Inventory/Inventory_Slot.png" id="1_slioy"]
 [ext_resource type="Texture2D" uid="uid://13nfhxsrmcv3" path="res://ArtAssets/InventoryItems/GearIcons/ArmorIcon.tres" id="2_b6onm"]
 [ext_resource type="FontFile" uid="uid://82lve5ogo12m" path="res://ArtAssets/Fonts/m5x7.ttf" id="3_4sj30"]
 [ext_resource type="Texture2D" uid="uid://egj4yak4x2ve" path="res://ArtAssets/UI/Inventory/MenuIndicate.tres" id="4_daruc"]
+[ext_resource type="Script" path="res://Core/UI/Scripts/InventorySlotView.cs" id="5_s7vbf"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_3ikqg"]
 bg_color = Color(0.993338, 0.844762, 0.620774, 1)
@@ -30,6 +31,7 @@ offset_right = 0.07999992
 offset_bottom = 0.07999992
 grow_horizontal = 2
 grow_vertical = 2
+script = ExtResource("5_s7vbf")
 
 [node name="TextureRect" type="TextureRect" parent="."]
 layout_mode = 1

--- a/PackedScenes/UI/PlayerUI.tscn
+++ b/PackedScenes/UI/PlayerUI.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=19 format=3 uid="uid://dblf2lc3y1xu1"]
+[gd_scene load_steps=20 format=3 uid="uid://dblf2lc3y1xu1"]
 
 [ext_resource type="Texture2D" uid="uid://dwddfu5bc1y1q" path="res://ArtAssets/UI/Icons/LootBag_U.png" id="1_01pqg"]
 [ext_resource type="Theme" uid="uid://dps46k28pmrlj" path="res://PackedScenes/UI/PlayerUI.tres" id="1_2hm7f"]
@@ -16,6 +16,7 @@
 [ext_resource type="Texture2D" uid="uid://d2d8rdvg2v01h" path="res://ArtAssets/UI/Icons/19.png" id="10_d1iv5"]
 [ext_resource type="Texture2D" uid="uid://mrqqt80opvaj" path="res://ArtAssets/UI/Inventory/Inventory_background.png" id="14_c8es7"]
 [ext_resource type="Texture2D" uid="uid://3efrmiudtjk1" path="res://ArtAssets/InventoryItems/GearIcons/tile034.png" id="15_yhkih"]
+[ext_resource type="Script" path="res://Core/UI/Scripts/PlayerMenu.cs" id="16_7guw0"]
 
 [sub_resource type="StyleBoxTexture" id="StyleBoxTexture_ggc4l"]
 content_margin_left = 16.0
@@ -47,6 +48,7 @@ anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
 theme = ExtResource("1_2hm7f")
+script = ExtResource("16_7guw0")
 
 [node name="NinePatchRect" type="PanelContainer" parent="."]
 layout_mode = 1


### PR DESCRIPTION
### Motivation
- Introduce a CSV-driven item repository and richer inventory model to support multiple item categories, equip/unequip behavior, and item effects.
- Provide runtime persistence for inventory stacks and equipped items and enable world pickups that add to the inventory.
- Improve item/effect abstractions so items can apply/remove stat modifiers on owners and be owned by `Entity` instances.

### Description
- Added CSV seed files `Core/Inventory/Data/items_seed.csv` and `item_effects_seed.csv` and extended `GameManager` to load items and item effects via new CSV-based loader calls `GetAllItems()` and `GetAllItemEffects()` using `MasterRepository.FillCsvRepo` and new export paths `ItemCsvPath` and `ItemEffectsCsvPath`.
- Implemented CSV parsing and loading in `MasterRepository` (`FillCsvRepo`, `ReadCsvRows`, `ParseCsvLine`, `LoadItemsFromCsv`, `LoadItemEffectsFromCsv`) and item factory `CreateInventoryItem` to produce typed `InventoryItem` subclasses (`ConsumeItem`, `CraftingItem`, `ArmorItem`, `WeaponItem`, `BasicInventoryItem`).
- Implemented effect types `PlusStat` and `MinusStat` with `ResolveItemEffect`/`RemoveItemEffect` logic to modify `IStats` properties and added `ItemEffects.SetOwner` support; built effects from CSV rows in the repo loader.
- Refactored `InventoryItem` to hold category/subtype/maxStack, expose `SetOwner`, fix `GetInfo` effect listing, and improved `Use` logging.
- Large `InventoryManager` rewrite: internal `_itemDict` stack map, equipment tracking (`_equippedArmorBySlot`, `_equippedWeaponBySlot`), `AddItem` now returns `bool` and enforces per-item `MaxStack`, implemented `DropItem`, `UseItem` handling for equips/consumables, snapshot/restore using `InventorySave`/`InventoryStackEntry` (preserves equipped state), and utility methods for toggling equips, consuming one, clearing/restoring equipment and query APIs (`GetItemCounts`, `GetEquippedArmorSlots`, `GetEquippedWeaponSlots`, `IsEquipped`).
- Updated `IInventory.AddItem` to return `bool` and propagated the change to `GameManager` wrapper.
- Added `ItemPickup` area node to pick up items into the inventory with optional interact requirement and quantity handling.
- Added UI pieces: `InventorySlotView` control and `PlayerMenu` UI controller, plus scene updates (`PlayerUI.tscn`, `inventory_slot.tscn`, `MasterNode.tscn`, `PackedScenes/EthraV1/Core/Scripts/UIRoot.cs`) to show/toggle the player inventory and display equipped/stacked items.

### Testing
- No automated tests were executed for this change set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e000462e58832686476892f6feeb70)