### PR TITLE
Add item icon & per-weapon sprite support, propagate visuals to player and inventory UI

### DIFF
--- a/Core/Inventory/Data/items_seed.csv
+++ b/Core/Inventory/Data/items_seed.csv
@@ -1,8 +1,8 @@
-id,name,description,rarity,sell_value,category,subtype,max_stack
-1001,Small Health Potion,Restores a small amount of HP,Common,5,Consumable,Potion,99
-2001,Rusted Sword,An old blade with low durability,Common,10,Weapon,Sword,1
-2002,Iron Longsword,Reliable steel blade,Uncommon,18,Weapon,Sword,1
-3001,Copper Ore,Base crafting ore,Common,2,Crafting,Ore,99
-4001,Leather Cap,Simple head protection,Common,8,Armor,Head,1
-4002,Traveler Hood,Lightweight hood armor,Uncommon,12,Armor,Head,1
-4101,Padded Vest,Simple chest protection,Common,9,Armor,Chest,1
+id,name,description,rarity,sell_value,category,subtype,max_stack,icon_path,weapon_up_draw_path,weapon_down_draw_path,weapon_up_stow_path,weapon_down_stow_path
+1001,Small Health Potion,Restores a small amount of HP,Common,5,Consumable,Potion,99,res://icon.svg,,,,
+2001,Rusted Sword,An old blade with low durability,Common,10,Weapon,Sword,1,res://icon.svg,res://ArtAssets/Characters/Selene/WepUp/Selene_Wepup_Sword_Draw.png,res://ArtAssets/Characters/Selene/WepDown/Selene_Wepdwn_Sword_Draw.png,res://ArtAssets/Characters/Selene/StowUp/Selene_Wepup_Sword_Stow.png,res://ArtAssets/Characters/Selene/StowDown/Selene_Wepdwn_Sword_Stow.png
+2002,Iron Longsword,Reliable steel blade,Uncommon,18,Weapon,Sword,1,res://icon.svg,res://ArtAssets/Characters/Selene/WepUp/Selene_Wepup_Sword_Draw.png,res://ArtAssets/Characters/Selene/WepDown/Selene_Wepdwn_Sword_Draw.png,res://ArtAssets/Characters/Selene/StowUp/Selene_Wepup_Sword_Stow.png,res://ArtAssets/Characters/Selene/StowDown/Selene_Wepdwn_Sword_Stow.png
+3001,Copper Ore,Base crafting ore,Common,2,Crafting,Ore,99,res://icon.svg,,,,
+4001,Leather Cap,Simple head protection,Common,8,Armor,Head,1,res://icon.svg,,,,
+4002,Traveler Hood,Lightweight hood armor,Uncommon,12,Armor,Head,1,res://icon.svg,,,,
+4101,Padded Vest,Simple chest protection,Common,9,Armor,Chest,1,res://icon.svg,,,,

--- a/Core/Inventory/Scripts/ArmorItem.cs
+++ b/Core/Inventory/Scripts/ArmorItem.cs
@@ -18,8 +18,9 @@ namespace ethra.V1
             string rarity,
             string slot,
             int maxStack,
-            List<ItemEffects> effects = null)
-            : base(id, name, value, description, rarity, effects, category: "Armor", subtype: slot, maxStack: maxStack)
+            List<ItemEffects> effects = null,
+            string iconPath = "")
+            : base(id, name, value, description, rarity, effects, category: "Armor", subtype: slot, maxStack: maxStack, iconPath: iconPath)
         {
         }
 

--- a/Core/Inventory/Scripts/BasicInventoryItem.cs
+++ b/Core/Inventory/Scripts/BasicInventoryItem.cs
@@ -13,8 +13,9 @@ namespace ethra.V1
             List<ItemEffects> effects = null,
             string category = "",
             string subtype = "",
-            int maxStack = 99)
-            : base(id, name, value, description, rarity, effects, category, subtype, maxStack)
+            int maxStack = 99,
+            string iconPath = "")
+            : base(id, name, value, description, rarity, effects, category, subtype, maxStack, iconPath)
         {
         }
     }

--- a/Core/Inventory/Scripts/ConsumeItem.cs
+++ b/Core/Inventory/Scripts/ConsumeItem.cs
@@ -15,8 +15,9 @@ namespace ethra.V1
             string rarity,
             string subtype,
             int maxStack,
-            List<ItemEffects> effects = null)
-            : base(id, name, value, description, rarity, effects, category: "Consumable", subtype: subtype, maxStack: maxStack)
+            List<ItemEffects> effects = null,
+            string iconPath = "")
+            : base(id, name, value, description, rarity, effects, category: "Consumable", subtype: subtype, maxStack: maxStack, iconPath: iconPath)
         {
         }
 

--- a/Core/Inventory/Scripts/CraftingItem.cs
+++ b/Core/Inventory/Scripts/CraftingItem.cs
@@ -15,8 +15,9 @@ namespace ethra.V1
             string rarity,
             string subtype,
             int maxStack,
-            List<ItemEffects> effects = null)
-            : base(id, name, value, description, rarity, effects, category: "Crafting", subtype: subtype, maxStack: maxStack)
+            List<ItemEffects> effects = null,
+            string iconPath = "")
+            : base(id, name, value, description, rarity, effects, category: "Crafting", subtype: subtype, maxStack: maxStack, iconPath: iconPath)
         {
         }
 

--- a/Core/Inventory/Scripts/InventoryItem.cs
+++ b/Core/Inventory/Scripts/InventoryItem.cs
@@ -13,6 +13,8 @@ namespace ethra.V1
         protected string _category;
         protected string _subtype;
         protected int _maxStack = 99;
+        protected string _iconPath;
+        protected Texture2D _icon;
         protected List<ItemEffects> _effects;
         protected int _resolveOrder = 15;
         protected Entity _owner;
@@ -25,6 +27,8 @@ namespace ethra.V1
         public string Category => _category;
         public string Subtype => _subtype;
         public int MaxStack => _maxStack;
+        public string IconPath => _iconPath;
+        public Texture2D Icon => _icon;
         public List<ItemEffects> Effects => _effects;
         public Entity Owner => _owner;
 
@@ -35,7 +39,7 @@ namespace ethra.V1
             _effects = new List<ItemEffects>();
         }
 
-        protected InventoryItem(int id, string name, int value, string description, string rarity, List<ItemEffects> effects = null, string category = "", string subtype = "", int maxStack = 99)
+        protected InventoryItem(int id, string name, int value, string description, string rarity, List<ItemEffects> effects = null, string category = "", string subtype = "", int maxStack = 99, string iconPath = "")
         {
             _id = id;
             _name = name;
@@ -45,7 +49,25 @@ namespace ethra.V1
             _category = category;
             _subtype = subtype;
             _maxStack = maxStack > 0 ? maxStack : 99;
+            _iconPath = iconPath;
+            _icon = LoadTexture(iconPath);
             _effects = effects ?? new List<ItemEffects>();
+        }
+
+        protected static Texture2D LoadTexture(string path)
+        {
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                return null;
+            }
+
+            Texture2D texture = ResourceLoader.Load<Texture2D>(path);
+            if (texture == null)
+            {
+                GD.PushWarning($"InventoryItem: failed to load icon texture at '{path}'.");
+            }
+
+            return texture;
         }
 
         public ItemInfo GetInfo()

--- a/Core/Inventory/Scripts/WeaponItem.cs
+++ b/Core/Inventory/Scripts/WeaponItem.cs
@@ -6,9 +6,17 @@ namespace ethra.V1
     public class WeaponItem : InventoryItem
     {
         private bool _isEquipped;
+        private Texture2D _weaponUpDraw;
+        private Texture2D _weaponDownDraw;
+        private Texture2D _weaponUpStow;
+        private Texture2D _weaponDownStow;
 
         public string WeaponSlot => "MainHand";
         public bool IsEquipped => _isEquipped;
+        public Texture2D WeaponUpDraw => _weaponUpDraw;
+        public Texture2D WeaponDownDraw => _weaponDownDraw;
+        public Texture2D WeaponUpStow => _weaponUpStow;
+        public Texture2D WeaponDownStow => _weaponDownStow;
 
         public WeaponItem(
             int id,
@@ -17,9 +25,18 @@ namespace ethra.V1
             string description,
             string rarity,
             int maxStack,
-            List<ItemEffects> effects = null)
-            : base(id, name, value, description, rarity, effects, category: "Weapon", subtype: "MainHand", maxStack: maxStack)
+            List<ItemEffects> effects = null,
+            string iconPath = "",
+            string weaponUpDrawPath = "",
+            string weaponDownDrawPath = "",
+            string weaponUpStowPath = "",
+            string weaponDownStowPath = "")
+            : base(id, name, value, description, rarity, effects, category: "Weapon", subtype: "MainHand", maxStack: maxStack, iconPath: iconPath)
         {
+            _weaponUpDraw = LoadTexture(weaponUpDrawPath);
+            _weaponDownDraw = LoadTexture(weaponDownDrawPath);
+            _weaponUpStow = LoadTexture(weaponUpStowPath);
+            _weaponDownStow = LoadTexture(weaponDownStowPath);
         }
 
         public void Equip()

--- a/Core/Managers/GameManager.cs
+++ b/Core/Managers/GameManager.cs
@@ -218,7 +218,7 @@ namespace ethra.V1
 
 				DB.FillCsvRepo(ItemCsvPath, MasterRepository.RepoLoadType.Items, new[]
 						{
-							"id", "name", "category", "description", "rarity", "sell_value", "subtype", "max_stack"
+							"id", "name", "category", "description", "rarity", "sell_value", "subtype", "max_stack", "icon_path", "weapon_up_draw_path", "weapon_down_draw_path", "weapon_up_stow_path", "weapon_down_stow_path"
 						});
 					}
 
@@ -235,12 +235,6 @@ namespace ethra.V1
 					"item_id", "effect_type", "effect_stat", "effect_power"
 				});
 		}
-
-			DB.FillCsvRepo(ItemCsvPath, MasterRepository.RepoLoadType.Items, new[]
-				{
-					"id", "name", "category", "description", "rarity", "sell_value", "subtype", "max_stack"
-				});
-			}
 
 	public void GetAllScenes()
 		{

--- a/Core/Managers/InventoryManager.cs
+++ b/Core/Managers/InventoryManager.cs
@@ -7,6 +7,7 @@ namespace ethra.V1
 {
     public partial class InventoryManager :  ISaveable, IInventory
 	{
+        private const bool DebugWeaponVisuals = true;
 		private string _saveKey = "Inventory";
         /// <summary>
         /// <id, count>
@@ -45,6 +46,7 @@ namespace ethra.V1
                 if(count + 1 <= maxAllowed)
                 {
                      _itemDict[id] = count + 1;
+                     Changed?.Invoke();
                      return true;
                 }
                 else
@@ -57,6 +59,7 @@ namespace ethra.V1
             else
             {
                 _itemDict.Add(id, 1);
+                Changed?.Invoke();
                 return true;
             }
         }
@@ -103,6 +106,7 @@ namespace ethra.V1
             }
 
             GD.Print($"Dropped item id:{id}. Remaining quantity: {_itemDict.GetValueOrDefault(id, 0)}");
+            Changed?.Invoke();
         }
 
 
@@ -114,6 +118,7 @@ namespace ethra.V1
             if(snapshot is InventorySave inventorySave)
             {
                 RestoreFromInventorySave(inventorySave);
+                Changed?.Invoke();
                 return;
             }
 
@@ -131,6 +136,8 @@ namespace ethra.V1
                     AddItem(i);
                 }
             }
+
+            Changed?.Invoke();
         }
 
         public void UseItem(int id)
@@ -154,12 +161,14 @@ namespace ethra.V1
                 if (itemToUse is ArmorItem armor)
                 {
                     ToggleArmorEquip(armor);
+                    Changed?.Invoke();
                     return;
                 }
 
                 if (itemToUse is WeaponItem weapon)
                 {
                     ToggleWeaponEquip(weapon);
+                    Changed?.Invoke();
                     return;
                 }
 
@@ -169,6 +178,7 @@ namespace ethra.V1
                 {
                     int remaining = ConsumeOne(id);
                     GD.Print($"Consumed item id:{id}. Remaining quantity: {remaining}");
+                    Changed?.Invoke();
                 }
             }
             else
@@ -215,6 +225,7 @@ namespace ethra.V1
                 {
                     weapon.Unequip();
                     _equippedWeaponBySlot.Remove(slot);
+                    ApplyEquippedWeaponVisuals();
                     return;
                 }
 
@@ -227,6 +238,7 @@ namespace ethra.V1
 
             weapon.Equip();
             _equippedWeaponBySlot[slot] = weapon.Id;
+            ApplyEquippedWeaponVisuals();
         }
 
         private int ConsumeOne(int id)
@@ -318,6 +330,8 @@ namespace ethra.V1
                     _equippedWeaponBySlot[kvp.Key] = kvp.Value;
                 }
             }
+
+            ApplyEquippedWeaponVisuals();
         }
 
         private void UnequipItemIfNeeded(int id)
@@ -345,6 +359,7 @@ namespace ethra.V1
             else if (item is WeaponItem weapon)
             {
                 weapon.Unequip();
+                ApplyEquippedWeaponVisuals();
                 string foundSlot = null;
                 foreach (var slot in _equippedWeaponBySlot)
                 {
@@ -382,6 +397,78 @@ namespace ethra.V1
 
             _equippedArmorBySlot.Clear();
             _equippedWeaponBySlot.Clear();
+            ApplyEquippedWeaponVisuals();
+        }
+
+        public IReadOnlyDictionary<int, int> GetItemCounts()
+        {
+            return new Dictionary<int, int>(_itemDict);
+        }
+
+        public IReadOnlyDictionary<string, int> GetEquippedArmor()
+        {
+            return new Dictionary<string, int>(_equippedArmorBySlot);
+        }
+
+        public IReadOnlyDictionary<string, int> GetEquippedWeapons()
+        {
+            return new Dictionary<string, int>(_equippedWeaponBySlot);
+        }
+
+        private void ApplyEquippedWeaponVisuals()
+        {
+            GameManager gm = GameManager.Instance;
+            if (gm == null)
+            {
+                if (DebugWeaponVisuals)
+                {
+                    GD.Print("InventoryManager.ApplyEquippedWeaponVisuals: skipped (GameManager.Instance is null).");
+                }
+                return;
+            }
+
+            SceneTree tree = gm.GetTree();
+            if (tree == null)
+            {
+                if (DebugWeaponVisuals)
+                {
+                    GD.Print("InventoryManager.ApplyEquippedWeaponVisuals: skipped (SceneTree is null).");
+                }
+                return;
+            }
+
+            PlayerNode playerNode = tree.GetFirstNodeInGroup("Player") as PlayerNode;
+            if (playerNode == null)
+            {
+                if (DebugWeaponVisuals)
+                {
+                    GD.Print("InventoryManager.ApplyEquippedWeaponVisuals: skipped (no PlayerNode in group 'Player').");
+                }
+                return;
+            }
+
+            if (_equippedWeaponBySlot.TryGetValue("MainHand", out int weaponId)
+                && _db.GetItemFromRepo(weaponId) is WeaponItem weapon)
+            {
+                if (DebugWeaponVisuals)
+                {
+                    GD.Print($"InventoryManager.ApplyEquippedWeaponVisuals: applying weapon id={weaponId} name='{weapon.Name}'.");
+                }
+
+                playerNode.ApplyWeaponSprites(
+                    weapon.WeaponUpDraw ?? gm.WepUpDraw,
+                    weapon.WeaponDownDraw ?? gm.WepDownDraw,
+                    weapon.WeaponUpStow ?? gm.WepUpStow,
+                    weapon.WeaponDownStow ?? gm.WepDownStow);
+                return;
+            }
+
+            if (DebugWeaponVisuals)
+            {
+                GD.Print("InventoryManager.ApplyEquippedWeaponVisuals: no equipped MainHand weapon, applying GameManager fallback sprites.");
+            }
+
+            playerNode.ApplyWeaponSprites(gm.WepUpDraw, gm.WepDownDraw, gm.WepUpStow, gm.WepDownStow);
         }
 
 

--- a/Core/Managers/MasterRepository.cs
+++ b/Core/Managers/MasterRepository.cs
@@ -290,6 +290,11 @@ namespace ethra.V1
 					string rarity = GetString(headerIndex, row, "rarity");
 						string category = GetString(headerIndex, row, "category");
 						string subtype = GetString(headerIndex, row, "subtype");
+						string iconPath = GetString(headerIndex, row, "icon_path");
+						string weaponUpDrawPath = GetString(headerIndex, row, "weapon_up_draw_path");
+						string weaponDownDrawPath = GetString(headerIndex, row, "weapon_down_draw_path");
+						string weaponUpStowPath = GetString(headerIndex, row, "weapon_up_stow_path");
+						string weaponDownStowPath = GetString(headerIndex, row, "weapon_down_stow_path");
 						int value = GetIntOrDefault(headerIndex, row, "sell_value", 0);
 						int maxStack = GetIntOrDefault(headerIndex, row, "max_stack", 99);
 
@@ -309,7 +314,12 @@ namespace ethra.V1
 								category,
 								subtype,
 								maxStack,
-								new List<ItemEffects>());
+								new List<ItemEffects>(),
+								iconPath,
+								weaponUpDrawPath,
+								weaponDownDrawPath,
+								weaponUpStowPath,
+								weaponDownStowPath);
 							_itemRepo.Add(id, item);
 							loaded++;
 						}
@@ -326,29 +336,46 @@ namespace ethra.V1
 				string category,
 				string subtype,
 				int maxStack,
-				List<ItemEffects> effects)
+				List<ItemEffects> effects,
+				string iconPath,
+				string weaponUpDrawPath,
+				string weaponDownDrawPath,
+				string weaponUpStowPath,
+				string weaponDownStowPath)
 			{
 				if (string.Equals(category, "Crafting", StringComparison.OrdinalIgnoreCase))
 				{
-					return new CraftingItem(id, name, value, description, rarity, subtype, maxStack, effects);
+					return new CraftingItem(id, name, value, description, rarity, subtype, maxStack, effects, iconPath);
 				}
 
 				if (string.Equals(category, "Consumable", StringComparison.OrdinalIgnoreCase))
 				{
-					return new ConsumeItem(id, name, value, description, rarity, subtype, maxStack, effects);
+					return new ConsumeItem(id, name, value, description, rarity, subtype, maxStack, effects, iconPath);
 				}
 
 				if (string.Equals(category, "Armor", StringComparison.OrdinalIgnoreCase))
 				{
-					return new ArmorItem(id, name, value, description, rarity, subtype, maxStack, effects);
+					return new ArmorItem(id, name, value, description, rarity, subtype, maxStack, effects, iconPath);
 				}
 
 				if (string.Equals(category, "Weapon", StringComparison.OrdinalIgnoreCase))
 				{
-					return new WeaponItem(id, name, value, description, rarity, maxStack, effects);
+					return new WeaponItem(
+						id,
+						name,
+						value,
+						description,
+						rarity,
+						maxStack,
+						effects,
+						iconPath,
+						weaponUpDrawPath,
+						weaponDownDrawPath,
+						weaponUpStowPath,
+						weaponDownStowPath);
 				}
 
-				return new BasicInventoryItem(id, name, value, description, rarity, effects, category: category, subtype: subtype, maxStack: maxStack);
+				return new BasicInventoryItem(id, name, value, description, rarity, effects, category: category, subtype: subtype, maxStack: maxStack, iconPath: iconPath);
 			}
 
 		private void LoadItemEffectsFromCsv(IReadOnlyList<string> headers, IReadOnlyList<string[]> rows, string sourcePath)

--- a/Core/Nodes/Entity/PlayerNode.cs
+++ b/Core/Nodes/Entity/PlayerNode.cs
@@ -7,6 +7,7 @@ namespace ethra.V1
 {
 	public partial class PlayerNode : CharacterBody2D
 	{
+		private const bool DebugWeaponVisuals = true;
 		private Player _player;
 		private AnimationPlayer _anim;
 		private GameManager _gm;
@@ -32,8 +33,19 @@ namespace ethra.V1
 		{
 			_anim = GetNodeOrNull<AnimationPlayer>("Actions");
 			_gm = GameManager.Instance;
+			_wepUpDraw = GetNodeOrNull<Sprite2D>("Sprites/WepUpDraw");
+			_wepDownDraw = GetNodeOrNull<Sprite2D>("Sprites/WepDownDraw");
+			_wepUpStow = GetNodeOrNull<Sprite2D>("Sprites/WepUpStow");
+			_wepDownStow = GetNodeOrNull<Sprite2D>("Sprites/WepDownStow");
+			_hair = GetNodeOrNull<Sprite2D>("Sprites/Hair");
+			_clothes = GetNodeOrNull<Sprite2D>("Sprites/Clothes");
+			_body = GetNodeOrNull<Sprite2D>("Sprites/Body");
+			_overlay = GetNodeOrNull<Sprite2D>("Sprites/Overlay");
 
-
+			if (_gm != null)
+			{
+				ApplyWeaponSprites(_gm.WepUpDraw, _gm.WepDownDraw, _gm.WepUpStow, _gm.WepDownStow);
+			}
 		}
 
 		public void Bind(Player player)
@@ -70,6 +82,45 @@ namespace ethra.V1
 					GD.PushWarning($"Animation not found: '{animName}'");
 				}
 			}
+		}
+
+		public void ApplyWeaponSprites(Texture2D upDraw, Texture2D downDraw, Texture2D upStow, Texture2D downStow)
+		{
+			if (_wepUpDraw != null && upDraw != null)
+			{
+				_wepUpDraw.Texture = upDraw;
+			}
+
+			if (_wepDownDraw != null && downDraw != null)
+			{
+				_wepDownDraw.Texture = downDraw;
+			}
+
+			if (_wepUpStow != null && upStow != null)
+			{
+				_wepUpStow.Texture = upStow;
+			}
+
+			if (_wepDownStow != null && downStow != null)
+			{
+				_wepDownStow.Texture = downStow;
+			}
+
+			if (DebugWeaponVisuals)
+			{
+				GD.Print(
+					$"PlayerNode.ApplyWeaponSprites: upDraw={TextureLabel(upDraw)}, downDraw={TextureLabel(downDraw)}, upStow={TextureLabel(upStow)}, downStow={TextureLabel(downStow)}");
+			}
+		}
+
+		private static string TextureLabel(Texture2D texture)
+		{
+			if (texture == null)
+			{
+				return "<null>";
+			}
+
+			return string.IsNullOrWhiteSpace(texture.ResourcePath) ? "<runtime>" : texture.ResourcePath;
 		}
 	}
 }

--- a/Core/UI/Scripts/InventorySlotView.cs
+++ b/Core/UI/Scripts/InventorySlotView.cs
@@ -35,6 +35,7 @@ namespace ethra.V1
             if (Icon != null)
             {
                 Icon.Visible = false;
+                Icon.Texture = null;
             }
 
             SetSelected(false);
@@ -54,6 +55,7 @@ namespace ethra.V1
             if (Icon != null)
             {
                 Icon.Visible = item != null;
+                Icon.Texture = item?.Icon;
             }
         }
 


### PR DESCRIPTION
### Motivation
- Add per-item icon and per-weapon sprite references so items can carry visual assets from CSV into runtime objects.
- Surface weapon visuals to the player node so equipped weapons show correct sprites instead of only global fallbacks.
- Ensure the inventory UI and systems are notified when inventory changes so views can update.

### Description
- Extended `items_seed.csv` columns to include `icon_path`, `weapon_up_draw_path`, `weapon_down_draw_path`, `weapon_up_stow_path`, and `weapon_down_stow_path` and populated sample rows.
- Added icon support to `InventoryItem` by storing `IconPath` and loading a `Texture2D` via `LoadTexture`, and exposed `Icon` on the item.
- Updated concrete item constructors (`BasicInventoryItem`, `ConsumeItem`, `CraftingItem`, `ArmorItem`, `WeaponItem`) and `MasterRepository.CreateInventoryItem` to accept and pass `iconPath` and weapon sprite paths; `WeaponItem` now loads and exposes its four weapon textures.
- Updated `GameManager.GetAllItems` to include the new CSV headers so the repo reads the new columns.
- Inventory behavior changes in `InventoryManager` include emitting `Changed` via `Changed?.Invoke()` on add/drop/restore/use, added read-only accessors `GetItemCounts`, `GetEquippedArmor`, and `GetEquippedWeapons`, and implemented `ApplyEquippedWeaponVisuals` which applies equipped weapon textures to the `PlayerNode` (with debug logging and fallbacks to `GameManager` sprites).
- `PlayerNode` now looks up sprite nodes in `_Ready`, initializes from `GameManager`, and exposes `ApplyWeaponSprites` to set weapon sprite textures and print debug info.
- `InventorySlotView` now sets and clears `Icon.Texture` when updating slot contents so UI icons reflect loaded item icons.

### Testing
- Built the project locally with `dotnet build` to verify compilation after API changes and asset loading additions, and the build succeeded.
- Ran the existing automated test suite with `dotnet test`; the existing tests completed successfully (no new tests were added for the visual features).
- Performed runtime smoke checks in the editor to verify weapon sprite application paths are used and inventory UI icons update, with debug logs confirming `ApplyWeaponSprites` runs when equipping/clearing weapons.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e513835860832682db6676b59dd36b)