### PR TITLE
Add weapon combo system, attack payloads, and combat resolution with player attack state

### DIFF
--- a/Core/Combat/Data/Combos/iron_longsword_combo.tres
+++ b/Core/Combat/Data/Combos/iron_longsword_combo.tres
@@ -1,0 +1,78 @@
+[gd_resource type="Resource" script_class="WeaponComboResource" load_steps=9 format=3]
+
+[ext_resource type="Script" path="res://Core/Combat/Scripts/WeaponComboResource.cs" id="1"]
+[ext_resource type="Script" path="res://Core/Combat/Scripts/ComboPhaseResource.cs" id="2"]
+[ext_resource type="Script" path="res://Core/Combat/Scripts/AttackPayloadResource.cs" id="3"]
+
+[sub_resource type="Resource" id="AttackPayloadResource_melee_1"]
+script = ExtResource("3")
+OverlayMode = 1
+ManaCost = 0
+DeliveryShapeId = "SingleTarget"
+DamageType = "Physical"
+ElementType = ""
+BasePower = 1.0
+EffectIds = Array[String]([])
+EffectDurationSeconds = 0.0
+
+[sub_resource type="Resource" id="AttackPayloadResource_magic_1"]
+script = ExtResource("3")
+OverlayMode = 2
+ManaCost = 12
+DeliveryShapeId = "Cone"
+DamageType = "Elemental"
+ElementType = "Ice"
+BasePower = 1.3
+EffectIds = Array[String](["Slow"])
+EffectDurationSeconds = 5.0
+
+[sub_resource type="Resource" id="AttackPayloadResource_melee_2"]
+script = ExtResource("3")
+OverlayMode = 1
+ManaCost = 0
+DeliveryShapeId = "Linear"
+DamageType = "Physical"
+ElementType = ""
+BasePower = 1.4
+EffectIds = Array[String](["Knockback"])
+EffectDurationSeconds = 0.0
+
+[sub_resource type="Resource" id="ComboPhaseResource_a"]
+script = ExtResource("2")
+SharedAnimationName = "Melee1"
+PreferFacingSuffix = true
+DurationOverrideSeconds = 0.0
+ActiveWindowStart = 0.0
+ActiveWindowEnd = 0.0
+BufferWindowStart = 0.0
+BufferWindowEnd = 0.0
+MeleePayload = SubResource("AttackPayloadResource_melee_1")
+MagicPayload = SubResource("AttackPayloadResource_magic_1")
+
+[sub_resource type="Resource" id="ComboPhaseResource_b"]
+script = ExtResource("2")
+SharedAnimationName = "Melee2"
+PreferFacingSuffix = true
+DurationOverrideSeconds = 0.0
+ActiveWindowStart = 0.0
+ActiveWindowEnd = 0.0
+BufferWindowStart = 0.0
+BufferWindowEnd = 0.0
+MeleePayload = SubResource("AttackPayloadResource_melee_2")
+MagicPayload = SubResource("AttackPayloadResource_magic_1")
+
+[sub_resource type="Resource" id="ComboPhaseResource_c"]
+script = ExtResource("2")
+SharedAnimationName = "Melee3"
+PreferFacingSuffix = true
+DurationOverrideSeconds = 0.0
+ActiveWindowStart = 0.0
+ActiveWindowEnd = 0.0
+BufferWindowStart = 0.0
+BufferWindowEnd = 0.0
+MeleePayload = SubResource("AttackPayloadResource_melee_2")
+MagicPayload = SubResource("AttackPayloadResource_magic_1")
+
+[resource]
+script = ExtResource("1")
+Phases = Array[Resource]([SubResource("ComboPhaseResource_a"), SubResource("ComboPhaseResource_b"), SubResource("ComboPhaseResource_c")])

--- a/Core/Combat/Data/Combos/rusted_sword_combo.tres
+++ b/Core/Combat/Data/Combos/rusted_sword_combo.tres
@@ -1,0 +1,78 @@
+[gd_resource type="Resource" script_class="WeaponComboResource" load_steps=9 format=3]
+
+[ext_resource type="Script" path="res://Core/Combat/Scripts/WeaponComboResource.cs" id="1"]
+[ext_resource type="Script" path="res://Core/Combat/Scripts/ComboPhaseResource.cs" id="2"]
+[ext_resource type="Script" path="res://Core/Combat/Scripts/AttackPayloadResource.cs" id="3"]
+
+[sub_resource type="Resource" id="AttackPayloadResource_melee_1"]
+script = ExtResource("3")
+OverlayMode = 1
+ManaCost = 0
+DeliveryShapeId = "SingleTarget"
+DamageType = "Physical"
+ElementType = ""
+BasePower = 1.0
+EffectIds = Array[String]([])
+EffectDurationSeconds = 0.0
+
+[sub_resource type="Resource" id="AttackPayloadResource_magic_1"]
+script = ExtResource("3")
+OverlayMode = 2
+ManaCost = 8
+DeliveryShapeId = "Cone"
+DamageType = "Elemental"
+ElementType = "Ice"
+BasePower = 1.1
+EffectIds = Array[String](["Slow"])
+EffectDurationSeconds = 5.0
+
+[sub_resource type="Resource" id="AttackPayloadResource_melee_2"]
+script = ExtResource("3")
+OverlayMode = 1
+ManaCost = 0
+DeliveryShapeId = "SingleTarget"
+DamageType = "Physical"
+ElementType = ""
+BasePower = 1.2
+EffectIds = Array[String](["Knockback"])
+EffectDurationSeconds = 0.0
+
+[sub_resource type="Resource" id="ComboPhaseResource_a"]
+script = ExtResource("2")
+SharedAnimationName = "Melee1"
+PreferFacingSuffix = true
+DurationOverrideSeconds = 0.0
+ActiveWindowStart = 0.0
+ActiveWindowEnd = 0.0
+BufferWindowStart = 0.0
+BufferWindowEnd = 0.0
+MeleePayload = SubResource("AttackPayloadResource_melee_1")
+MagicPayload = SubResource("AttackPayloadResource_magic_1")
+
+[sub_resource type="Resource" id="ComboPhaseResource_b"]
+script = ExtResource("2")
+SharedAnimationName = "Melee2"
+PreferFacingSuffix = true
+DurationOverrideSeconds = 0.0
+ActiveWindowStart = 0.0
+ActiveWindowEnd = 0.0
+BufferWindowStart = 0.0
+BufferWindowEnd = 0.0
+MeleePayload = SubResource("AttackPayloadResource_melee_2")
+MagicPayload = SubResource("AttackPayloadResource_magic_1")
+
+[sub_resource type="Resource" id="ComboPhaseResource_c"]
+script = ExtResource("2")
+SharedAnimationName = "Melee3"
+PreferFacingSuffix = true
+DurationOverrideSeconds = 0.0
+ActiveWindowStart = 0.0
+ActiveWindowEnd = 0.0
+BufferWindowStart = 0.0
+BufferWindowEnd = 0.0
+MeleePayload = SubResource("AttackPayloadResource_melee_2")
+MagicPayload = SubResource("AttackPayloadResource_magic_1")
+
+[resource]
+script = ExtResource("1")
+Phases = Array[Resource]([SubResource("ComboPhaseResource_a"), SubResource("ComboPhaseResource_b"), SubResource("ComboPhaseResource_c")])

--- a/Core/Combat/Scripts/AttackPayloadPacket.cs
+++ b/Core/Combat/Scripts/AttackPayloadPacket.cs
@@ -1,0 +1,13 @@
+namespace ethra.V1
+{
+    public sealed class AttackPayloadPacket
+    {
+        public Entity Source { get; init; }
+        public AttackPayloadResource Payload { get; init; }
+        public int ComboPhase { get; init; }
+        public FacingDirection Facing { get; init; }
+        public string AnimationName { get; init; } = string.Empty;
+        public Godot.Vector2 OriginPosition { get; init; } = Godot.Vector2.Zero;
+        public Godot.Vector2 ForwardDirection { get; init; } = Godot.Vector2.Zero;
+    }
+}

--- a/Core/Combat/Scripts/AttackPayloadResource.cs
+++ b/Core/Combat/Scripts/AttackPayloadResource.cs
@@ -1,0 +1,19 @@
+using Godot;
+
+namespace ethra.V1
+{
+    [GlobalClass]
+    public partial class AttackPayloadResource : Resource
+    {
+        [Export] public AttackOverlayMode OverlayMode { get; set; } = AttackOverlayMode.Melee;
+        [Export] public int ManaCost { get; set; } = 0;
+
+        [Export] public string DeliveryShapeId { get; set; } = "SingleTarget";
+        [Export] public string DamageType { get; set; } = "Physical";
+        [Export] public string ElementType { get; set; } = string.Empty;
+        [Export] public float BasePower { get; set; } = 1f;
+
+        [Export] public Godot.Collections.Array<string> EffectIds { get; set; } = new();
+        [Export] public float EffectDurationSeconds { get; set; } = 0f;
+    }
+}

--- a/Core/Combat/Scripts/CombatFeedbackBus.cs
+++ b/Core/Combat/Scripts/CombatFeedbackBus.cs
@@ -1,0 +1,74 @@
+using Godot;
+using System;
+
+namespace ethra.V1
+{
+    /// <summary>
+    /// Logging-first feedback bus for combat presentation hooks.
+    /// Current implementation is intentionally lightweight for pixel-art animation-layer workflows.
+    /// </summary>
+    public static class CombatFeedbackBus
+    {
+        public static bool DebugLoggingEnabled { get; set; } = true;
+
+        public static event Action<Player, int, string, AttackOverlayMode> AttackPhaseStarted;
+        public static event Action<Player, bool, float, float> ActiveWindowChanged;
+        public static event Action<Player, bool, float, float> BufferWindowChanged;
+        public static event Action<AttackPayloadPacket> PayloadQueued;
+        public static event Action<Player, int, int> MagicDenied;
+        public static event Action<Entity, Entity, float, bool, string, string> HitResolved;
+        public static event Action<Entity, string, float> EffectApplied;
+
+        public static void EmitAttackPhaseStarted(Player player, int phase, string clip, AttackOverlayMode overlay)
+        {
+            Log($"AttackPhaseStarted: source={player?.Name} phase={phase} clip='{clip}' overlay={overlay}");
+            AttackPhaseStarted?.Invoke(player, phase, clip, overlay);
+        }
+
+        public static void EmitActiveWindowChanged(Player player, bool isOpen, float elapsed, float duration)
+        {
+            Log($"ActiveWindowChanged: source={player?.Name} open={isOpen} t={elapsed:0.###}/{duration:0.###}");
+            ActiveWindowChanged?.Invoke(player, isOpen, elapsed, duration);
+        }
+
+        public static void EmitBufferWindowChanged(Player player, bool isOpen, float elapsed, float duration)
+        {
+            Log($"BufferWindowChanged: source={player?.Name} open={isOpen} t={elapsed:0.###}/{duration:0.###}");
+            BufferWindowChanged?.Invoke(player, isOpen, elapsed, duration);
+        }
+
+        public static void EmitPayloadQueued(AttackPayloadPacket packet)
+        {
+            Log($"PayloadQueued: source={packet?.Source?.Name} phase={packet?.ComboPhase} shape={packet?.Payload?.DeliveryShapeId}");
+            PayloadQueued?.Invoke(packet);
+        }
+
+        public static void EmitMagicDenied(Player player, int required, int current)
+        {
+            Log($"MagicDenied: source={player?.Name} required={required} current={current}");
+            MagicDenied?.Invoke(player, required, current);
+        }
+
+        public static void EmitHitResolved(Entity source, Entity target, float damage, bool crit, string damageType, string element)
+        {
+            Log($"HitResolved: source={source?.Name} target={target?.Name} damage={damage:0.###} crit={crit} type={damageType} element={element}");
+            HitResolved?.Invoke(source, target, damage, crit, damageType, element);
+        }
+
+        public static void EmitEffectApplied(Entity target, string effectId, float duration)
+        {
+            Log($"EffectApplied: target={target?.Name} effect={effectId} duration={duration:0.###}");
+            EffectApplied?.Invoke(target, effectId, duration);
+        }
+
+        private static void Log(string message)
+        {
+            if (!DebugLoggingEnabled)
+            {
+                return;
+            }
+
+            GD.Print($"[CombatFeedback] {message}");
+        }
+    }
+}

--- a/Core/Combat/Scripts/ComboPhaseResource.cs
+++ b/Core/Combat/Scripts/ComboPhaseResource.cs
@@ -1,0 +1,20 @@
+using Godot;
+
+namespace ethra.V1
+{
+    [GlobalClass]
+    public partial class ComboPhaseResource : Resource
+    {
+        [Export] public string SharedAnimationName { get; set; } = "Melee1";
+        [Export] public bool PreferFacingSuffix { get; set; } = true;
+        [Export] public float DurationOverrideSeconds { get; set; } = 0f;
+
+        [Export] public float ActiveWindowStart { get; set; } = 0f;
+        [Export] public float ActiveWindowEnd { get; set; } = 0f;
+        [Export] public float BufferWindowStart { get; set; } = 0f;
+        [Export] public float BufferWindowEnd { get; set; } = 0f;
+
+        [Export] public AttackPayloadResource MeleePayload { get; set; }
+        [Export] public AttackPayloadResource MagicPayload { get; set; }
+    }
+}

--- a/Core/Combat/Scripts/WeaponComboResource.cs
+++ b/Core/Combat/Scripts/WeaponComboResource.cs
@@ -1,0 +1,22 @@
+using Godot;
+
+namespace ethra.V1
+{
+    [GlobalClass]
+    public partial class WeaponComboResource : Resource
+    {
+        [Export] public Godot.Collections.Array<ComboPhaseResource> Phases { get; set; } = new();
+
+        public ComboPhaseResource GetPhaseForStep(int phase)
+        {
+            if (Phases == null || Phases.Count == 0)
+            {
+                return null;
+            }
+
+            int clampedPhase = Mathf.Max(1, phase);
+            int idx = Mathf.Min(clampedPhase - 1, Phases.Count - 1);
+            return Phases[idx];
+        }
+    }
+}

--- a/Core/Entity/Scripts/CombatEntity.cs
+++ b/Core/Entity/Scripts/CombatEntity.cs
@@ -22,9 +22,49 @@ namespace ethra.V1
         private int _luk;
 
         public int MaxHP {get{return _maxHP;} set{_maxHP = value;}}
-        public int CurHP {get{return _curHP;} set{if(_curHP + value > _maxHP){_curHP = _maxHP;} else {_curHP += value;}}}
+        public int CurHP
+        {
+            get { return _curHP; }
+            set
+            {
+                int next = _curHP + value;
+                if (next > _maxHP)
+                {
+                    _curHP = _maxHP;
+                    return;
+                }
+
+                if (next < 0)
+                {
+                    _curHP = 0;
+                    return;
+                }
+
+                _curHP = next;
+            }
+        }
         public int MaxMana {get{return _maxMana;} set{_maxMana = value;}}
-        public int CurMana {get{return _curMana;} set{if(_curMana + value > _maxMana){_curMana = _maxMana;} else {_curMana += value;}}}
+        public int CurMana
+        {
+            get { return _curMana; }
+            set
+            {
+                int next = _curMana + value;
+                if (next > _maxMana)
+                {
+                    _curMana = _maxMana;
+                    return;
+                }
+
+                if (next < 0)
+                {
+                    _curMana = 0;
+                    return;
+                }
+
+                _curMana = next;
+            }
+        }
         public int Strength {get{return _str;} set {if(_str + value > 99){_str = 99;} else{_str = value;}}}
         public int Dexterity {get{return _dex;} set {if(_dex + value > 99){_dex = 99;} else{_dex = value;}}}
         public int Intelligence {get{return _int;} set {if(_int + value > 99){_int = 99;} else{_int = value;}}}

--- a/Core/Entity/Scripts/Player.cs
+++ b/Core/Entity/Scripts/Player.cs
@@ -1,20 +1,26 @@
-
 using System.Collections.Generic;
 using System.Linq;
 using Godot;
 
 namespace ethra.V1
 {
+    public enum AttackInputType
+    {
+        Melee,
+        Magic
+    }
+
+    public enum AttackOverlayMode
+    {
+        None,
+        Melee,
+        Magic
+    }
+
     public partial class Player : CombatEntity, IPlayer
     {
         private IInventory _inventory;
-
         private Vector2 _moveInput;
-        
-
-        
-
-        
 
         public Vector2 MoveInput
         {
@@ -26,40 +32,44 @@ namespace ethra.V1
                 if (_moveInput.LengthSquared() < 0.001f)
                     return;
 
-                
                 if (Mathf.Abs(_moveInput.X) > Mathf.Abs(_moveInput.Y))
-                {
                     Facing = _moveInput.X > 0 ? FacingDirection.Right : FacingDirection.Left;
-                }
                 else
-                {
                     Facing = _moveInput.Y > 0 ? FacingDirection.Down : FacingDirection.Up;
-                }
-                    
             }
         }
 
         public bool AttackPressed { get; set; } = false;
+        public bool MeleePressed { get; set; } = false;
+        public bool MagicPressed { get; set; } = false;
+        public AttackInputType PendingAttackInput { get; set; } = AttackInputType.Melee;
+        public AttackOverlayMode CurrentAttackOverlay { get; set; } = AttackOverlayMode.None;
+        public AttackPayloadResource CurrentAttackPayload { get; set; } = null;
+        public AttackInputType? ComboBufferedInput { get; set; } = null;
+        public bool ComboBufferOpen { get; set; } = false;
+        public bool ComboAdvanceQueued { get; set; } = false;
+        public bool ComboCanExitAttack { get; set; } = false;
+        public bool AttackActiveWindowOpen { get; set; } = false;
+        public float CurrentPhaseElapsed { get; set; } = 0f;
+        public float CurrentPhaseDuration { get; set; } = 0f;
+
         public bool RunPressed { get; set; } = false;
         public bool DodgePressed { get; set; } = false;
         public float DodgeTimerRemaining { get; set; } = 0f;
+        public float AttackTimerRemaining { get; set; } = 0f;
+        public int AttackPhase { get; set; } = 1;
 
-        public Player(IEntityManager entity, ICombat combat, IInventory inventory, IStateMachine fsm): base (entity, combat, fsm)
+        public Player(IEntityManager entity, ICombat combat, IInventory inventory, IStateMachine fsm) : base(entity, combat, fsm)
         {
             _inventory = inventory;
-   
         }
 
         public override void Initialize()
         {
-            // Build player states here — leaf responsibility
-            var gm = GameManager.Instance; // see patch #6 below
+            var gm = GameManager.Instance;
+            float moveSpeed = gm != null ? gm.MoveSpeed : 120f;
 
-
-			float moveSpeed = gm != null ? gm.MoveSpeed : 120f;
-
-
-			var states = PlayerStateBuilder.PlayerStates(this, moveSpeed);
+            var states = PlayerStateBuilder.PlayerStates(this, moveSpeed);
             var idle = states.First(s => s.StateID == "Idle");
 
             SetStates(states);
@@ -74,11 +84,5 @@ namespace ethra.V1
             SetStates(states);
             SetInitialState(idle);
         }
-
-
-        
-       
-
-
     }
 }

--- a/Core/Entity/Scripts/StateMachine/Actions/AttackAction.cs
+++ b/Core/Entity/Scripts/StateMachine/Actions/AttackAction.cs
@@ -1,0 +1,459 @@
+using System.Collections.Generic;
+using Godot;
+
+namespace ethra.V1.Actions
+{
+    public sealed class AttackAction : IStateAction
+    {
+        private const string PlayerAnimLibraryPath = "res://ArtAssets/AnimationLibraries/playerActions.tres";
+        private const bool DebugCombatFlow = true;
+
+        private static AnimationLibrary _playerAnimLibrary;
+        private readonly float _fallbackDuration;
+
+        private string _clipName = "Melee1";
+        private float _activeStart;
+        private float _activeEnd;
+        private float _bufferStart;
+        private float _bufferEnd;
+        private bool _lastActiveWindowOpen;
+        private bool _lastBufferWindowOpen;
+
+        public AttackAction(float fallbackDuration = 0.25f)
+        {
+            _fallbackDuration = fallbackDuration;
+        }
+
+        public void Enter(Entity owner, BaseState baseState)
+        {
+            if (owner is not Player player)
+            {
+                return;
+            }
+
+            if (player.AttackPhase < 1)
+            {
+                player.AttackPhase = 1;
+            }
+
+            player.ComboBufferedInput = null;
+            player.ComboAdvanceQueued = false;
+            player.ComboCanExitAttack = false;
+            _lastActiveWindowOpen = false;
+            _lastBufferWindowOpen = false;
+
+            StartPhase(owner, player, player.AttackPhase, player.PendingAttackInput);
+        }
+
+        public void Execute(float delta, Entity owner, BaseState baseState)
+        {
+            if (owner is not Player player)
+            {
+                return;
+            }
+
+            AdvancePhaseTimers(player, delta);
+            CaptureBufferedInput(player);
+
+            if (player.AttackTimerRemaining <= 0f)
+            {
+                if (player.ComboAdvanceQueued && TryGetNextPhase(player, out int nextPhase, out AttackInputType nextInput))
+                {
+                    Log($"Execute: advancing combo phase {player.AttackPhase} -> {nextPhase} via buffered input={nextInput}.");
+                    StartPhase(owner, player, nextPhase, nextInput);
+                    return;
+                }
+
+                player.ComboCanExitAttack = true;
+            }
+
+            owner.RequestedAnimation = _clipName;
+            owner.DesiredVelocity = Vector2.Zero;
+        }
+
+        public void Exit(Entity owner)
+        {
+            if (owner is not Player player)
+            {
+                return;
+            }
+
+            player.AttackTimerRemaining = 0f;
+            player.CurrentAttackOverlay = AttackOverlayMode.None;
+            player.CurrentAttackPayload = null;
+            player.ComboBufferedInput = null;
+            player.ComboBufferOpen = false;
+            player.ComboAdvanceQueued = false;
+            player.ComboCanExitAttack = false;
+            player.AttackActiveWindowOpen = false;
+            player.CurrentPhaseElapsed = 0f;
+            player.CurrentPhaseDuration = 0f;
+            player.AttackPhase = 1;
+        }
+
+        private void StartPhase(Entity owner, Player player, int phase, AttackInputType requestedInput)
+        {
+            player.AttackPhase = phase;
+            player.PendingAttackInput = requestedInput;
+            player.ComboBufferedInput = null;
+            player.ComboAdvanceQueued = false;
+            player.ComboCanExitAttack = false;
+
+            float resolvedDuration = 0f;
+            ComboPhaseResource phaseResource = ResolveBestClip(player, out resolvedDuration, out _clipName);
+
+            owner.RequestedAnimation = _clipName;
+            owner.DesiredVelocity = Vector2.Zero;
+            player.AttackTimerRemaining = resolvedDuration > 0f ? resolvedDuration : _fallbackDuration;
+            player.CurrentPhaseDuration = player.AttackTimerRemaining;
+            player.CurrentPhaseElapsed = 0f;
+
+            ConfigureWindows(player.CurrentPhaseDuration, phaseResource);
+            UpdateWindowFlags(player);
+            QueuePayload(player, _clipName);
+            CombatFeedbackBus.EmitAttackPhaseStarted(player, phase, _clipName, player.CurrentAttackOverlay);
+
+            Log($"StartPhase: phase={phase} input={requestedInput} clip='{_clipName}' duration={player.CurrentPhaseDuration:0.###} active=[{_activeStart:0.###},{_activeEnd:0.###}] buffer=[{_bufferStart:0.###},{_bufferEnd:0.###}]");
+        }
+
+        private void AdvancePhaseTimers(Player player, float delta)
+        {
+            player.CurrentPhaseElapsed = Mathf.Min(player.CurrentPhaseDuration, player.CurrentPhaseElapsed + delta);
+            player.AttackTimerRemaining = Mathf.Max(0f, player.AttackTimerRemaining - delta);
+            UpdateWindowFlags(player);
+        }
+
+        private void UpdateWindowFlags(Player player)
+        {
+            float t = player.CurrentPhaseElapsed;
+            player.AttackActiveWindowOpen = t >= _activeStart && t <= _activeEnd;
+            player.ComboBufferOpen = t >= _bufferStart && t <= _bufferEnd;
+
+            if (player.AttackActiveWindowOpen != _lastActiveWindowOpen)
+            {
+                _lastActiveWindowOpen = player.AttackActiveWindowOpen;
+                CombatFeedbackBus.EmitActiveWindowChanged(player, player.AttackActiveWindowOpen, player.CurrentPhaseElapsed, player.CurrentPhaseDuration);
+            }
+
+            if (player.ComboBufferOpen != _lastBufferWindowOpen)
+            {
+                _lastBufferWindowOpen = player.ComboBufferOpen;
+                CombatFeedbackBus.EmitBufferWindowChanged(player, player.ComboBufferOpen, player.CurrentPhaseElapsed, player.CurrentPhaseDuration);
+            }
+        }
+
+        private void CaptureBufferedInput(Player player)
+        {
+            if (!player.ComboBufferOpen)
+            {
+                return;
+            }
+
+            bool requestedThisFrame = player.MeleePressed || player.MagicPressed;
+            if (!requestedThisFrame)
+            {
+                return;
+            }
+
+            AttackInputType buffered = player.MagicPressed ? AttackInputType.Magic : AttackInputType.Melee;
+            player.ComboBufferedInput = buffered;
+            player.ComboAdvanceQueued = true;
+            Log($"CaptureBufferedInput: buffered={buffered} at t={player.CurrentPhaseElapsed:0.###}/{player.CurrentPhaseDuration:0.###}");
+        }
+
+        private bool TryGetNextPhase(Player player, out int nextPhase, out AttackInputType input)
+        {
+            nextPhase = player.AttackPhase;
+            input = player.PendingAttackInput;
+
+            WeaponItem weapon = GetEquippedMainHandWeapon();
+            int phaseCount = weapon?.ComboProfile?.Phases?.Count ?? 0;
+
+            if (phaseCount <= 0)
+            {
+                return false;
+            }
+
+            if (player.AttackPhase >= phaseCount)
+            {
+                return false;
+            }
+
+            nextPhase = player.AttackPhase + 1;
+            input = player.ComboBufferedInput ?? player.PendingAttackInput;
+            return true;
+        }
+
+        private static float ResolveDuration(string clipName)
+        {
+            _playerAnimLibrary ??= ResourceLoader.Load<AnimationLibrary>(PlayerAnimLibraryPath);
+            if (_playerAnimLibrary == null)
+            {
+                return 0f;
+            }
+
+            Animation animation = _playerAnimLibrary.GetAnimation(clipName);
+            return animation?.Length ?? 0f;
+        }
+
+        private ComboPhaseResource ResolveBestClip(Player player, out float duration, out string clipName)
+        {
+            _playerAnimLibrary ??= ResourceLoader.Load<AnimationLibrary>(PlayerAnimLibraryPath);
+
+            ComboPhaseResource comboPhase = ResolveComboPhase(player, out string comboClip, out float comboDuration);
+            if (comboPhase != null)
+            {
+                duration = comboDuration;
+                clipName = comboClip;
+                Log($"ResolveBestClip: combo profile clip='{comboClip}' duration={comboDuration:0.###}");
+                return comboPhase;
+            }
+
+            foreach (string candidate in BuildFallbackClipCandidates(player))
+            {
+                float candidateDuration = ResolveDuration(candidate);
+                if (candidateDuration > 0f)
+                {
+                    player.CurrentAttackOverlay = player.PendingAttackInput == AttackInputType.Magic
+                        ? AttackOverlayMode.Magic
+                        : AttackOverlayMode.Melee;
+                    duration = candidateDuration;
+                    clipName = candidate;
+                    Log($"ResolveBestClip: fallback clip='{candidate}' duration={candidateDuration:0.###}");
+                    return null;
+                }
+            }
+
+            player.CurrentAttackOverlay = AttackOverlayMode.Melee;
+            duration = ResolveDuration("Melee1");
+            clipName = "Melee1";
+            return null;
+        }
+
+        private ComboPhaseResource ResolveComboPhase(Player player, out string clipName, out float duration)
+        {
+            clipName = null;
+            duration = 0f;
+
+            WeaponItem weapon = GetEquippedMainHandWeapon();
+            ComboPhaseResource phase = weapon?.ComboProfile?.GetPhaseForStep(player.AttackPhase);
+            if (phase == null)
+            {
+                Log($"ResolveComboPhase: no phase found for step={player.AttackPhase}.");
+                return null;
+            }
+
+            AttackPayloadResource payload = PickPayloadForInput(player, phase);
+            if (payload == null)
+            {
+                Log($"ResolveComboPhase: payload not resolved for phase={player.AttackPhase}.");
+                return null;
+            }
+
+            player.CurrentAttackPayload = payload;
+            player.CurrentAttackOverlay = payload.OverlayMode;
+            Log($"ResolveComboPhase: payload shape={payload.DeliveryShapeId} dmgType={payload.DamageType} element={payload.ElementType} overlay={payload.OverlayMode}");
+
+            foreach (string candidate in BuildPhaseClipCandidates(phase, player.Facing))
+            {
+                float clipDuration = ResolveDuration(candidate);
+                if (clipDuration <= 0f)
+                {
+                    continue;
+                }
+
+                clipName = candidate;
+                duration = phase.DurationOverrideSeconds > 0f ? phase.DurationOverrideSeconds : clipDuration;
+                Log($"ResolveComboPhase: resolved shared animation='{candidate}' duration={duration:0.###}");
+                return phase;
+            }
+
+            Log($"ResolveComboPhase: no animation found for shared clip='{phase.SharedAnimationName}'.");
+            return null;
+        }
+
+        private static AttackPayloadResource PickPayloadForInput(Player player, ComboPhaseResource phase)
+        {
+            bool wantsMagic = player.PendingAttackInput == AttackInputType.Magic;
+            AttackPayloadResource melee = phase.MeleePayload;
+            AttackPayloadResource magic = phase.MagicPayload;
+
+            if (wantsMagic && magic != null)
+            {
+                int manaCost = Mathf.Max(0, magic.ManaCost);
+                if (player.CurMana >= manaCost)
+                {
+                    if (manaCost > 0)
+                    {
+                        player.CurMana = -manaCost;
+                    }
+
+                    Log($"PickPayloadForInput: magic selected (cost={manaCost}, manaRemaining={player.CurMana}).");
+                    return magic;
+                }
+
+                Log($"PickPayloadForInput: insufficient mana for magic (required={manaCost}, current={player.CurMana}), falling back.");
+                CombatFeedbackBus.EmitMagicDenied(player, manaCost, player.CurMana);
+            }
+
+            Log("PickPayloadForInput: melee payload selected.");
+            return melee ?? magic;
+        }
+
+        private static void QueuePayload(Player player, string animationName)
+        {
+            if (player.CurrentAttackPayload == null)
+            {
+                return;
+            }
+
+            GameManager gm = GameManager.Instance;
+            if (gm?.Combat == null)
+            {
+                return;
+            }
+
+            GetOwnerTransform(player, out Vector2 origin, out Vector2 forward);
+
+            AttackPayloadPacket packet = new AttackPayloadPacket
+            {
+                Source = player,
+                Payload = player.CurrentAttackPayload,
+                ComboPhase = player.AttackPhase,
+                Facing = player.Facing,
+                AnimationName = animationName,
+                OriginPosition = origin,
+                ForwardDirection = forward
+            };
+
+            gm.Combat.QueueAttackPayload(packet);
+            CombatFeedbackBus.EmitPayloadQueued(packet);
+
+            Log($"QueuePayload: queued phase={player.AttackPhase} clip='{animationName}' origin={origin} forward={forward}");
+        }
+
+        private static WeaponItem GetEquippedMainHandWeapon()
+        {
+            GameManager gm = GameManager.Instance;
+            if (gm?.Inventory == null || gm.DB == null)
+            {
+                return null;
+            }
+
+            IReadOnlyDictionary<string, int> equipped = gm.Inventory.GetEquippedWeapons();
+            if (equipped == null || !equipped.TryGetValue("MainHand", out int weaponId))
+            {
+                return null;
+            }
+
+            return gm.DB.GetItemFromRepo(weaponId) as WeaponItem;
+        }
+
+        private void ConfigureWindows(float phaseDuration, ComboPhaseResource phase)
+        {
+            if (phase == null)
+            {
+                _activeStart = 0f;
+                _activeEnd = phaseDuration;
+                _bufferStart = phaseDuration * 0.45f;
+                _bufferEnd = phaseDuration;
+                return;
+            }
+
+            _activeStart = Mathf.Clamp(phase.ActiveWindowStart, 0f, phaseDuration);
+            _activeEnd = Mathf.Clamp(phase.ActiveWindowEnd, _activeStart, phaseDuration);
+            _bufferStart = Mathf.Clamp(phase.BufferWindowStart, 0f, phaseDuration);
+            _bufferEnd = Mathf.Clamp(phase.BufferWindowEnd, _bufferStart, phaseDuration);
+        }
+
+        private static void GetOwnerTransform(Player player, out Vector2 origin, out Vector2 forward)
+        {
+            origin = Vector2.Zero;
+            forward = player.Facing switch
+            {
+                FacingDirection.Up => Vector2.Up,
+                FacingDirection.Down => Vector2.Down,
+                FacingDirection.Left => Vector2.Left,
+                FacingDirection.Right => Vector2.Right,
+                _ => Vector2.Down
+            };
+
+            Node root = GameManager.Instance;
+            if (root?.GetTree() == null)
+            {
+                return;
+            }
+
+            PlayerNode playerNode = root.GetTree().GetFirstNodeInGroup("Player") as PlayerNode;
+            if (playerNode == null)
+            {
+                return;
+            }
+
+            origin = playerNode.GlobalPosition;
+        }
+
+        private static List<string> BuildPhaseClipCandidates(ComboPhaseResource phase, FacingDirection facing)
+        {
+            var clips = new List<string>();
+            string baseName = phase?.SharedAnimationName?.Trim();
+            if (string.IsNullOrWhiteSpace(baseName))
+            {
+                return clips;
+            }
+
+            if (phase.PreferFacingSuffix)
+            {
+                clips.Add($"{baseName}_{facing}");
+            }
+
+            clips.Add(baseName);
+
+            if (!phase.PreferFacingSuffix)
+            {
+                clips.Add($"{baseName}_{facing}");
+            }
+
+            return clips;
+        }
+
+        private static List<string> BuildFallbackClipCandidates(Player player)
+        {
+            string facing = player.Facing.ToString();
+            int phase = Mathf.Max(1, player.AttackPhase);
+
+            if (player.PendingAttackInput == AttackInputType.Magic)
+            {
+                return new List<string>
+                {
+                    $"Magic{phase}_{facing}",
+                    $"Magic{phase}",
+                    $"Cast{phase}_{facing}",
+                    $"Cast{phase}",
+                    "Melee1"
+                };
+            }
+
+            return new List<string>
+            {
+                $"Melee{phase}_{facing}",
+                $"Melee{phase}",
+                $"Attack{phase}_{facing}",
+                $"Attack{phase}",
+                $"Attack_{facing}",
+                "Attack",
+                "Melee1"
+            };
+        }
+
+        private static void Log(string message)
+        {
+            if (!DebugCombatFlow)
+            {
+                return;
+            }
+
+            GD.Print($"[AttackAction] {message}");
+        }
+    }
+}

--- a/Core/Entity/Scripts/StateMachine/States/Utility/PlayerStateBuilder.cs
+++ b/Core/Entity/Scripts/StateMachine/States/Utility/PlayerStateBuilder.cs
@@ -69,18 +69,33 @@ namespace ethra.V1
             );
             
 
+            BaseState attack = new BaseState
+            (
+                "Attack",
+                owner,
+                baseActions: new List<IStateAction>
+                {
+                    new AttackAction()
+                },
+                baseTransitions: new List<IStateTransition>()
+            );
+            
             idle.Transitions.Add(new DodgePressedTransition(dodge));
             idle.Transitions.Add(new MoveInputNonZeroTransition(walk));
             idle.Transitions.Add(new RunPressedTransition(run));
+            idle.Transitions.Add(new AttackPressedTransition(attack));
             walk.Transitions.Add(new DodgePressedTransition(dodge));
             walk.Transitions.Add(new MoveInputZeroTransition(idle));
             walk.Transitions.Add(new RunPressedTransition(run));
+            walk.Transitions.Add(new AttackPressedTransition(attack));
             run.Transitions.Add(new DodgePressedTransition(dodge));
             run.Transitions.Add(new MoveInputZeroTransition(idle));
             run.Transitions.Add(new RunReleasedTransition(walk));
+            run.Transitions.Add(new AttackPressedTransition(attack));
             dodge.Transitions.Add(new DodgeCompleteTransition(idle, walk, run));
+            attack.Transitions.Add(new AttackCompleteTransition(idle, walk, run));
 
-            return new List<BaseState> {idle, walk, run, dodge};
+            return new List<BaseState> {idle, walk, run, dodge, attack};
 
         }
 

--- a/Core/Entity/Scripts/StateMachine/Transitions/Locomotion/AttackCompleteTransition.cs
+++ b/Core/Entity/Scripts/StateMachine/Transitions/Locomotion/AttackCompleteTransition.cs
@@ -1,0 +1,56 @@
+namespace ethra.V1.Transitions
+{
+    /// <summary>
+    /// Leaves Attack once its animation-duration timer is complete.
+    /// Selects locomotion target based on current move/run input.
+    /// ONLY WORKS FOR PLAYER.
+    /// </summary>
+    public sealed class AttackCompleteTransition : IStateTransition
+    {
+        private readonly BaseState _idleTarget;
+        private readonly BaseState _walkTarget;
+        private readonly BaseState _runTarget;
+        private readonly float _deadZone;
+
+        private BaseState _chosenTarget;
+
+        public BaseState Target => _chosenTarget ?? _idleTarget;
+
+        public AttackCompleteTransition(BaseState idleTarget, BaseState walkTarget, BaseState runTarget, float deadZone = 0.05f)
+        {
+            _idleTarget = idleTarget;
+            _walkTarget = walkTarget;
+            _runTarget = runTarget;
+            _deadZone = deadZone;
+            _chosenTarget = _idleTarget;
+        }
+
+        public bool ShouldTransition(Entity owner)
+        {
+            if (owner is not Player player)
+            {
+                return false;
+            }
+
+            if (player.AttackTimerRemaining > 0f)
+            {
+                return false;
+            }
+
+            if (!player.ComboCanExitAttack)
+            {
+                return false;
+            }
+
+            bool isMoving = player.MoveInput.LengthSquared() > (_deadZone * _deadZone);
+            if (!isMoving)
+            {
+                _chosenTarget = _idleTarget;
+                return true;
+            }
+
+            _chosenTarget = player.RunPressed ? _runTarget : _walkTarget;
+            return true;
+        }
+    }
+}

--- a/Core/Entity/Scripts/StateMachine/Transitions/Locomotion/AttackPressedTransition.cs
+++ b/Core/Entity/Scripts/StateMachine/Transitions/Locomotion/AttackPressedTransition.cs
@@ -1,0 +1,26 @@
+namespace ethra.V1.Transitions
+{
+    /// <summary>
+    /// Transition when Attack input was pressed this frame.
+    /// ONLY WORKS FOR PLAYER.
+    /// </summary>
+    public sealed class AttackPressedTransition : IStateTransition
+    {
+        public BaseState Target { get; }
+
+        public AttackPressedTransition(BaseState target)
+        {
+            Target = target;
+        }
+
+        public bool ShouldTransition(Entity owner)
+        {
+            if (owner is Player player)
+            {
+                return player.AttackPressed;
+            }
+
+            return false;
+        }
+    }
+}

--- a/Core/Inventory/Data/items_seed.csv
+++ b/Core/Inventory/Data/items_seed.csv
@@ -1,8 +1,8 @@
-id,name,description,rarity,sell_value,category,subtype,max_stack,icon_path,weapon_up_draw_path,weapon_down_draw_path,weapon_up_stow_path,weapon_down_stow_path
-1001,Small Health Potion,Restores a small amount of HP,Common,5,Consumable,Potion,99,res://ArtAssets/InventoryItems/Consume/HealthPotion.tres,,,,
-2001,Rusted Sword,An old blade with low durability,Common,10,Weapon,Sword,1,res://ArtAssets/InventoryItems/GearIcons/Rusty_Short_Sword_Sprite.tres,res://ArtAssets/Characters/Selene/WepUp/Selene_Wepup_Sword_Draw.png,res://ArtAssets/Characters/Selene/WepDown/Selene_Wepdwn_Sword_Draw.png,res://ArtAssets/Characters/Selene/StowUp/Selene_Wepup_Sword_Stow.png,res://ArtAssets/Characters/Selene/StowDown/Selene_Wepdwn_Sword_Stow.png
-2002,Iron Longsword,Reliable steel blade,Uncommon,18,Weapon,Sword,1,res://ArtAssets/InventoryItems/GearIcons/Knight_Blade_Sprite.tres,res://ArtAssets/Characters/Selene/WepUp/Selene_Wepup_Sword_Draw.png,res://ArtAssets/Characters/Selene/WepDown/Selene_Wepdwn_Sword_Draw.png,res://ArtAssets/Characters/Selene/StowUp/Selene_Wepup_Sword_Stow.png,res://ArtAssets/Characters/Selene/StowDown/Selene_Wepdwn_Sword_Stow.png
-3001,Copper Ore,Base crafting ore,Common,2,Crafting,Ore,99,res://ArtAssets/UI/Icons/15.png,,,,
-4001,Leather Cap,Simple head protection,Common,8,Armor,Head,1,res://ArtAssets/InventoryItems/GearIcons/tile079.png,,,,
-4002,Traveler Hood,Lightweight hood armor,Uncommon,12,Armor,Head,1,res://ArtAssets/InventoryItems/GearIcons/tile076.png,,,,
-4101,Padded Vest,Simple chest protection,Common,9,Armor,Chest,1,res://ArtAssets/InventoryItems/GearIcons/tile073.png,,,,
+id,name,description,rarity,sell_value,category,subtype,max_stack,icon_path,weapon_up_draw_path,weapon_down_draw_path,weapon_up_stow_path,weapon_down_stow_path,combo_profile_path
+1001,Small Health Potion,Restores a small amount of HP,Common,5,Consumable,Potion,99,res://ArtAssets/InventoryItems/Consume/HealthPotion.tres,,,,,
+2001,Rusted Sword,An old blade with low durability,Common,10,Weapon,Sword,1,res://ArtAssets/InventoryItems/GearIcons/Rusty_Short_Sword_Sprite.tres,res://ArtAssets/Characters/Selene/WepUp/Selene_Wepup_Sword_Draw.png,res://ArtAssets/Characters/Selene/WepDown/Selene_Wepdwn_Sword_Draw.png,res://ArtAssets/Characters/Selene/StowUp/Selene_Wepup_Sword_Stow.png,res://ArtAssets/Characters/Selene/StowDown/Selene_Wepdwn_Sword_Stow.png,res://Core/Combat/Data/Combos/rusted_sword_combo.tres
+2002,Iron Longsword,Reliable steel blade,Uncommon,18,Weapon,Sword,1,res://ArtAssets/InventoryItems/GearIcons/Knight_Blade_Sprite.tres,res://ArtAssets/Characters/Selene/WepUp/Selene_Wepup_Sword_Draw.png,res://ArtAssets/Characters/Selene/WepDown/Selene_Wepdwn_Sword_Draw.png,res://ArtAssets/Characters/Selene/StowUp/Selene_Wepup_Sword_Stow.png,res://ArtAssets/Characters/Selene/StowDown/Selene_Wepdwn_Sword_Stow.png,res://Core/Combat/Data/Combos/iron_longsword_combo.tres
+3001,Copper Ore,Base crafting ore,Common,2,Crafting,Ore,99,res://ArtAssets/UI/Icons/15.png,,,,,
+4001,Leather Cap,Simple head protection,Common,8,Armor,Head,1,res://ArtAssets/InventoryItems/GearIcons/tile079.png,,,,,
+4002,Traveler Hood,Lightweight hood armor,Uncommon,12,Armor,Head,1,res://ArtAssets/InventoryItems/GearIcons/tile076.png,,,,,
+4101,Padded Vest,Simple chest protection,Common,9,Armor,Chest,1,res://ArtAssets/InventoryItems/GearIcons/tile073.png,,,,,

--- a/Core/Inventory/Scripts/WeaponItem.cs
+++ b/Core/Inventory/Scripts/WeaponItem.cs
@@ -5,11 +5,14 @@ namespace ethra.V1
 {
     public class WeaponItem : InventoryItem
     {
+        private const bool DebugComboProfiles = true;
         private bool _isEquipped;
         private Texture2D _weaponUpDraw;
         private Texture2D _weaponDownDraw;
         private Texture2D _weaponUpStow;
         private Texture2D _weaponDownStow;
+        private string _comboProfilePath;
+        private WeaponComboResource _comboProfile;
 
         public string WeaponSlot => "MainHand";
         public bool IsEquipped => _isEquipped;
@@ -17,6 +20,8 @@ namespace ethra.V1
         public Texture2D WeaponDownDraw => _weaponDownDraw;
         public Texture2D WeaponUpStow => _weaponUpStow;
         public Texture2D WeaponDownStow => _weaponDownStow;
+        public string ComboProfilePath => _comboProfilePath;
+        public WeaponComboResource ComboProfile => _comboProfile ??= LoadComboProfile(_comboProfilePath);
 
         public WeaponItem(
             int id,
@@ -30,13 +35,15 @@ namespace ethra.V1
             string weaponUpDrawPath = "",
             string weaponDownDrawPath = "",
             string weaponUpStowPath = "",
-            string weaponDownStowPath = "")
+            string weaponDownStowPath = "",
+            string comboProfilePath = "")
             : base(id, name, value, description, rarity, effects, category: "Weapon", subtype: "MainHand", maxStack: maxStack, iconPath: iconPath)
         {
             _weaponUpDraw = LoadTexture(weaponUpDrawPath);
             _weaponDownDraw = LoadTexture(weaponDownDrawPath);
             _weaponUpStow = LoadTexture(weaponUpStowPath);
             _weaponDownStow = LoadTexture(weaponDownStowPath);
+            _comboProfilePath = comboProfilePath;
         }
 
         public void Equip()
@@ -87,6 +94,26 @@ namespace ethra.V1
             {
                 Equip();
             }
+        }
+
+        private static WeaponComboResource LoadComboProfile(string path)
+        {
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                return null;
+            }
+
+            WeaponComboResource profile = ResourceLoader.Load<WeaponComboResource>(path);
+            if (profile == null)
+            {
+                GD.PushWarning($"WeaponItem: failed to load combo profile at '{path}'.");
+            }
+            else if (DebugComboProfiles)
+            {
+                GD.Print($"WeaponItem: loaded combo profile '{path}' with phaseCount={profile.Phases?.Count ?? 0}.");
+            }
+
+            return profile;
         }
     }
 }

--- a/Core/Managers/CombatManager.cs
+++ b/Core/Managers/CombatManager.cs
@@ -1,80 +1,433 @@
 using Godot;
 using System;
-using ethra.V1;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace ethra.V1
 {
-    public partial class CombatManager :  ISaveable, ICombat, IResolveable
-{
-        private string _saveKey = "Combat";
-        private int _resolveOrder = 20;
-        public string SaveKey => _saveKey;
+    public partial class CombatManager : ISaveable, ICombat, IResolveable
+    {
+        private sealed class StatusRuntime
+        {
+            public string Id { get; init; } = string.Empty;
+            public int Stacks { get; set; }
+            public float RemainingSeconds { get; set; }
+            public Entity Source { get; set; }
+        }
 
+        private const bool DebugCombatFlow = true;
+        private const float CritMultiplier = 1.5f;
+
+        private readonly string _saveKey = "Combat";
+        private readonly int _resolveOrder = 20;
+        private readonly Queue<AttackPayloadPacket> _payloadQueue = new();
+        private readonly Dictionary<string, Func<AttackPayloadPacket, IReadOnlyList<Entity>>> _deliveryHandlers = new(StringComparer.OrdinalIgnoreCase);
+        private readonly Dictionary<string, Action<Entity, AttackPayloadPacket, string>> _effectHandlers = new(StringComparer.OrdinalIgnoreCase);
+        private readonly Dictionary<Entity, Dictionary<string, StatusRuntime>> _activeStatuses = new();
+        private readonly RandomNumberGenerator _rng = new();
+
+        public string SaveKey => _saveKey;
         public int ResolveOrder => _resolveOrder;
 
-        //=====ICOmbat=====//
+        public CombatManager()
+        {
+            _rng.Randomize();
+            RegisterDefaultHandlers();
+        }
+
+        public void QueueAttackPayload(AttackPayloadPacket packet)
+        {
+            if (packet?.Payload == null)
+            {
+                return;
+            }
+
+            _payloadQueue.Enqueue(packet);
+            Log($"QueueAttackPayload: queued source={packet.Source?.Name} phase={packet.ComboPhase} shape={packet.Payload.DeliveryShapeId} queueCount={_payloadQueue.Count}");
+        }
 
         public void ApplyStatus(Entity target, string statusId, int stacks = 1, float? durationSeconds = null, Entity source = null)
         {
-            throw new NotImplementedException();
+            if (target == null || string.IsNullOrWhiteSpace(statusId) || stacks <= 0)
+            {
+                return;
+            }
+
+            if (!_activeStatuses.TryGetValue(target, out Dictionary<string, StatusRuntime> statusMap))
+            {
+                statusMap = new Dictionary<string, StatusRuntime>(StringComparer.OrdinalIgnoreCase);
+                _activeStatuses[target] = statusMap;
+            }
+
+            if (!statusMap.TryGetValue(statusId, out StatusRuntime runtime))
+            {
+                runtime = new StatusRuntime
+                {
+                    Id = statusId,
+                    Stacks = 0,
+                    RemainingSeconds = 0f,
+                    Source = source
+                };
+                statusMap[statusId] = runtime;
+            }
+
+            runtime.Stacks += stacks;
+            runtime.Source = source;
+            if (durationSeconds.HasValue)
+            {
+                runtime.RemainingSeconds = Mathf.Max(runtime.RemainingSeconds, durationSeconds.Value);
+            }
+
+            Log($"ApplyStatus: target={target.Name} id={statusId} stacks={runtime.Stacks} remaining={runtime.RemainingSeconds:0.###}");
         }
 
         public bool CanHit(Entity attacker, Entity target, string abilityId)
         {
-            throw new NotImplementedException();
+            if (attacker == null || target == null)
+            {
+                return false;
+            }
+
+            if (target is IStats targetStats && targetStats.CurHP <= 0)
+            {
+                return false;
+            }
+
+            return true;
         }
-         public bool TryResolveAttack(Entity attacker, Entity target, string abilityId, out float finalDamage, out bool isCritical)
+
+        public bool TryResolveAttack(Entity attacker, Entity target, string abilityId, out float finalDamage, out bool isCritical)
         {
-            throw new NotImplementedException();
+            finalDamage = 0f;
+            isCritical = false;
+
+            if (!CanHit(attacker, target, abilityId))
+            {
+                return false;
+            }
+
+            AttackPayloadResource payload = BuildAdHocPayload(abilityId);
+            finalDamage = ComputeDamage(attacker, target, payload, out isCritical);
+            return finalDamage > 0f;
         }
-        
 
         public void DealAreaDamage(IEnumerable<Entity> targets, float amount, string damageType = "Physical", Entity source = null, IEnumerable<string> tags = null, IEnumerable<string> statusIds = null)
         {
-            throw new NotImplementedException();
+            if (targets == null)
+            {
+                return;
+            }
+
+            foreach (Entity target in targets)
+            {
+                DealDamage(target, amount, damageType, source, tags);
+
+                if (statusIds == null)
+                {
+                    continue;
+                }
+
+                foreach (string status in statusIds)
+                {
+                    ApplyStatus(target, status, 1, null, source);
+                }
+            }
         }
 
         public void DealDamage(Entity target, float amount, string damageType = "Physical", Entity source = null, IEnumerable<string> tags = null)
         {
-            throw new NotImplementedException();
+            if (target is not IStats stats)
+            {
+                return;
+            }
+
+            int delta = -Mathf.Max(1, Mathf.RoundToInt(amount));
+            stats.CurHP = delta;
+            Log($"DealDamage: target={target.Name} amount={-delta} type={damageType} hpNow={stats.CurHP}");
         }
 
         public void Heal(Entity target, float amount, Entity source = null, IEnumerable<string> tags = null)
         {
-            throw new NotImplementedException();
+            if (target is not IStats stats)
+            {
+                return;
+            }
+
+            int delta = Mathf.Max(1, Mathf.RoundToInt(amount));
+            stats.CurHP = delta;
+            Log($"Heal: target={target.Name} amount={delta} hpNow={stats.CurHP}");
         }
 
         public float PreviewDamage(Entity attacker, Entity target, string abilityId)
         {
-            throw new NotImplementedException();
+            AttackPayloadResource payload = BuildAdHocPayload(abilityId);
+            return ComputeExpectedDamage(attacker, target, payload);
         }
 
         public void RemoveStatus(Entity target, string statusId, int stacks = int.MaxValue)
         {
-            throw new NotImplementedException();
+            if (target == null || string.IsNullOrWhiteSpace(statusId))
+            {
+                return;
+            }
+
+            if (!_activeStatuses.TryGetValue(target, out Dictionary<string, StatusRuntime> statusMap))
+            {
+                return;
+            }
+
+            if (!statusMap.TryGetValue(statusId, out StatusRuntime runtime))
+            {
+                return;
+            }
+
+            if (stacks >= runtime.Stacks)
+            {
+                statusMap.Remove(statusId);
+                Log($"RemoveStatus: target={target.Name} id={statusId} removed=all");
+            }
+            else
+            {
+                runtime.Stacks -= stacks;
+                Log($"RemoveStatus: target={target.Name} id={statusId} removed={stacks} remainingStacks={runtime.Stacks}");
+            }
+
+            if (statusMap.Count == 0)
+            {
+                _activeStatuses.Remove(target);
+            }
         }
-        //======IResolvable======//
+
         public void Resolve()
         {
-            
+            while (_payloadQueue.Count > 0)
+            {
+                AttackPayloadPacket packet = _payloadQueue.Dequeue();
+                Log($"Resolve: dequeued source={packet.Source?.Name} phase={packet.ComboPhase} remaining={_payloadQueue.Count}");
+                ExecuteAttackPayload(packet);
+            }
         }
 
         public void Resolve(object obj)
         {
-            
+            if (obj is double d)
+            {
+                TickStatuses((float)d);
+                return;
+            }
+
+            if (obj is float f)
+            {
+                TickStatuses(f);
+            }
         }
-        //=======ISavable========//
+
         public void RestoreSnapshot(object snapshot)
         {
             throw new NotImplementedException();
         }
+
         public object CaptureSnapshot()
         {
             throw new NotImplementedException();
         }
-       
 
+        private void ExecuteAttackPayload(AttackPayloadPacket packet)
+        {
+            AttackPayloadResource payload = packet.Payload;
+            string shapeId = string.IsNullOrWhiteSpace(payload.DeliveryShapeId) ? "SingleTarget" : payload.DeliveryShapeId;
+            Log($"ExecuteAttackPayload: source={packet.Source?.Name} phase={packet.ComboPhase} anim='{packet.AnimationName}' origin={packet.OriginPosition} forward={packet.ForwardDirection} shape={shapeId} damageType={payload.DamageType} element={payload.ElementType}");
+
+            IReadOnlyList<Entity> targets = _deliveryHandlers.TryGetValue(shapeId, out Func<AttackPayloadPacket, IReadOnlyList<Entity>> deliveryHandler)
+                ? deliveryHandler(packet)
+                : Array.Empty<Entity>();
+
+            if (targets.Count == 0)
+            {
+                Log($"ExecuteAttackPayload: no targets resolved for shape='{shapeId}'.");
+            }
+
+            foreach (Entity target in targets)
+            {
+                float damage = ComputeDamage(packet.Source, target, payload, out bool crit);
+                if (damage > 0f)
+                {
+                    DealDamage(target, damage, payload.DamageType, packet.Source);
+                }
+
+                Log($"ExecuteAttackPayload: target={target.Name} damage={damage:0.###} crit={crit}");
+                CombatFeedbackBus.EmitHitResolved(packet.Source, target, damage, crit, payload.DamageType, payload.ElementType);
+
+                if (payload.EffectIds == null)
+                {
+                    continue;
+                }
+
+                foreach (string effectId in payload.EffectIds)
+                {
+                    if (string.IsNullOrWhiteSpace(effectId))
+                    {
+                        continue;
+                    }
+
+                    if (_effectHandlers.TryGetValue(effectId, out Action<Entity, AttackPayloadPacket, string> effectHandler))
+                    {
+                        Log($"ExecuteAttackPayload: applying effect='{effectId}' duration={payload.EffectDurationSeconds:0.###}");
+                        effectHandler(target, packet, effectId);
+                        CombatFeedbackBus.EmitEffectApplied(target, effectId, payload.EffectDurationSeconds);
+                    }
+                    else
+                    {
+                        GD.PushWarning($"CombatManager: unknown effect id '{effectId}' for payload.");
+                    }
+                }
+            }
+        }
+
+        private void RegisterDefaultHandlers()
+        {
+            Log("RegisterDefaultHandlers: registering default delivery/effect handlers.");
+
+            _deliveryHandlers["SingleTarget"] = packet =>
+            {
+                List<Entity> targets = GetEnemyTargets();
+                if (targets.Count > 1)
+                {
+                    targets = new List<Entity> { targets[0] };
+                }
+                return targets;
+            };
+
+            _deliveryHandlers["Cone"] = packet => GetEnemyTargets();
+            _deliveryHandlers["Linear"] = packet => GetEnemyTargets();
+
+            _effectHandlers["Knockback"] = (target, packet, effectId) =>
+                ApplyStatus(target, "Knockback", 1, packet.Payload.EffectDurationSeconds, packet.Source);
+
+            _effectHandlers["Slow"] = (target, packet, effectId) =>
+                ApplyStatus(target, "Slow", 1, packet.Payload.EffectDurationSeconds, packet.Source);
+
+            _effectHandlers["Stun"] = (target, packet, effectId) =>
+                ApplyStatus(target, "Stun", 1, packet.Payload.EffectDurationSeconds, packet.Source);
+
+            _effectHandlers["Root"] = (target, packet, effectId) =>
+                ApplyStatus(target, "Root", 1, packet.Payload.EffectDurationSeconds, packet.Source);
+        }
+
+        private List<Entity> GetEnemyTargets()
+        {
+            GameManager gm = GameManager.Instance;
+            if (gm?.registeredEnemies == null)
+            {
+                return new List<Entity>();
+            }
+
+            return gm.registeredEnemies
+                .Where(enemy => enemy != null)
+                .Cast<Entity>()
+                .ToList();
+        }
+
+        private float ComputeDamage(Entity attacker, Entity target, AttackPayloadResource payload, out bool isCritical)
+        {
+            isCritical = false;
+            if (attacker is not IStats attackerStats || target is not IStats targetStats)
+            {
+                return 0f;
+            }
+
+            int mainStat = payload.OverlayMode == AttackOverlayMode.Magic
+                ? attackerStats.Intelligence
+                : attackerStats.Strength;
+
+            float baseDamage = payload.BasePower * (1f + mainStat * 0.05f);
+            float critChance = Mathf.Clamp(0.02f + attackerStats.Dexterity * 0.002f + attackerStats.Luck * 0.001f, 0f, 0.65f);
+
+            if (_rng.Randf() <= critChance)
+            {
+                isCritical = true;
+                baseDamage *= CritMultiplier;
+            }
+
+            float mitigation = Mathf.Clamp(targetStats.Vitality * 0.005f, 0f, 0.60f);
+            float finalDamage = Mathf.Max(1f, baseDamage * (1f - mitigation));
+            return finalDamage;
+        }
+
+        private float ComputeExpectedDamage(Entity attacker, Entity target, AttackPayloadResource payload)
+        {
+            if (attacker is not IStats attackerStats || target is not IStats targetStats)
+            {
+                return 0f;
+            }
+
+            int mainStat = payload.OverlayMode == AttackOverlayMode.Magic
+                ? attackerStats.Intelligence
+                : attackerStats.Strength;
+
+            float baseDamage = payload.BasePower * (1f + mainStat * 0.05f);
+            float critChance = Mathf.Clamp(0.02f + attackerStats.Dexterity * 0.002f + attackerStats.Luck * 0.001f, 0f, 0.65f);
+            float expectedCritFactor = 1f + critChance * (CritMultiplier - 1f);
+            float mitigation = Mathf.Clamp(targetStats.Vitality * 0.005f, 0f, 0.60f);
+            return Mathf.Max(1f, baseDamage * expectedCritFactor * (1f - mitigation));
+        }
+
+        private AttackPayloadResource BuildAdHocPayload(string abilityId)
+        {
+            AttackOverlayMode mode = abilityId != null && abilityId.Contains("magic", StringComparison.OrdinalIgnoreCase)
+                ? AttackOverlayMode.Magic
+                : AttackOverlayMode.Melee;
+
+            return new AttackPayloadResource
+            {
+                OverlayMode = mode,
+                BasePower = 1f,
+                DamageType = mode == AttackOverlayMode.Magic ? "Elemental" : "Physical",
+                ElementType = mode == AttackOverlayMode.Magic ? "Arcane" : string.Empty,
+                DeliveryShapeId = "SingleTarget"
+            };
+        }
+
+        private void TickStatuses(float delta)
+        {
+            if (delta <= 0f || _activeStatuses.Count == 0)
+            {
+                return;
+            }
+
+            List<(Entity target, string status)> expired = new();
+
+            foreach ((Entity target, Dictionary<string, StatusRuntime> statuses) in _activeStatuses)
+            {
+                foreach ((string statusId, StatusRuntime runtime) in statuses)
+                {
+                    if (runtime.RemainingSeconds <= 0f)
+                    {
+                        continue;
+                    }
+
+                    runtime.RemainingSeconds = Mathf.Max(0f, runtime.RemainingSeconds - delta);
+                    if (runtime.RemainingSeconds <= 0f)
+                    {
+                        expired.Add((target, statusId));
+                    }
+                }
+            }
+
+            foreach ((Entity target, string status) in expired)
+            {
+                RemoveStatus(target, status, int.MaxValue);
+            }
+        }
+
+        private static void Log(string message)
+        {
+            if (!DebugCombatFlow)
+            {
+                return;
+            }
+
+            GD.Print($"[CombatManager] {message}");
+        }
     }
 }
-

--- a/Core/Managers/GameManager.cs
+++ b/Core/Managers/GameManager.cs
@@ -218,7 +218,7 @@ namespace ethra.V1
 
 				DB.FillCsvRepo(ItemCsvPath, MasterRepository.RepoLoadType.Items, new[]
 						{
-							"id", "name", "category", "description", "rarity", "sell_value", "subtype", "max_stack", "icon_path", "weapon_up_draw_path", "weapon_down_draw_path", "weapon_up_stow_path", "weapon_down_stow_path"
+							"id", "name", "category", "description", "rarity", "sell_value", "subtype", "max_stack", "icon_path", "weapon_up_draw_path", "weapon_down_draw_path", "weapon_up_stow_path", "weapon_down_stow_path", "combo_profile_path"
 						});
 					}
 

--- a/Core/Managers/MasterRepository.cs
+++ b/Core/Managers/MasterRepository.cs
@@ -295,6 +295,7 @@ namespace ethra.V1
 						string weaponDownDrawPath = GetString(headerIndex, row, "weapon_down_draw_path");
 						string weaponUpStowPath = GetString(headerIndex, row, "weapon_up_stow_path");
 						string weaponDownStowPath = GetString(headerIndex, row, "weapon_down_stow_path");
+						string comboProfilePath = GetString(headerIndex, row, "combo_profile_path");
 						int value = GetIntOrDefault(headerIndex, row, "sell_value", 0);
 						int maxStack = GetIntOrDefault(headerIndex, row, "max_stack", 99);
 
@@ -319,7 +320,8 @@ namespace ethra.V1
 								weaponUpDrawPath,
 								weaponDownDrawPath,
 								weaponUpStowPath,
-								weaponDownStowPath);
+								weaponDownStowPath,
+								comboProfilePath);
 							_itemRepo.Add(id, item);
 							loaded++;
 						}
@@ -341,7 +343,8 @@ namespace ethra.V1
 				string weaponUpDrawPath,
 				string weaponDownDrawPath,
 				string weaponUpStowPath,
-				string weaponDownStowPath)
+				string weaponDownStowPath,
+				string comboProfilePath)
 			{
 				if (string.Equals(category, "Crafting", StringComparison.OrdinalIgnoreCase))
 				{
@@ -372,7 +375,8 @@ namespace ethra.V1
 						weaponUpDrawPath,
 						weaponDownDrawPath,
 						weaponUpStowPath,
-						weaponDownStowPath);
+						weaponDownStowPath,
+						comboProfilePath);
 				}
 
 				return new BasicInventoryItem(id, name, value, description, rarity, effects, category: category, subtype: subtype, maxStack: maxStack, iconPath: iconPath);

--- a/Core/Nodes/Entity/PlayerNode.cs
+++ b/Core/Nodes/Entity/PlayerNode.cs
@@ -8,10 +8,13 @@ namespace ethra.V1
 	public partial class PlayerNode : CharacterBody2D
 	{
 		private const bool DebugWeaponVisuals = true;
+		private const bool DebugCombatInput = true;
+		private const bool DebugCombatFeedback = true;
 		private Player _player;
 		private AnimationPlayer _anim;
 		private GameManager _gm;
 		private string _lastAnim = "";
+		private AttackOverlayMode _lastOverlayMode = AttackOverlayMode.None;
 
 		#region Sprites
 
@@ -60,7 +63,19 @@ namespace ethra.V1
 			_player.MoveInput = Input.GetVector("Left", "Right", "Up", "Down");
 			_player.RunPressed = Input.IsActionPressed("Run");
 			_player.DodgePressed = Input.IsActionJustPressed("Dodge");
+			_player.MeleePressed = Input.IsActionJustPressed("Attack");
+			_player.MagicPressed = Input.IsActionJustPressed("MagicAttack");
+			_player.AttackPressed = _player.MeleePressed || _player.MagicPressed;
+			if (_player.AttackPressed)
+			{
+				_player.PendingAttackInput = _player.MagicPressed ? AttackInputType.Magic : AttackInputType.Melee;
+				if (DebugCombatInput)
+				{
+					GD.Print($"PlayerNode: attack input queued type={_player.PendingAttackInput} phase={_player.AttackPhase}");
+				}
+			}
 			_player.Tick(dt);
+			ApplyAttackOverlay(_player.CurrentAttackOverlay);
 
 			Velocity = _player.DesiredVelocity;
 
@@ -81,6 +96,24 @@ namespace ethra.V1
 				{
 					GD.PushWarning($"Animation not found: '{animName}'");
 				}
+			}
+		}
+
+
+		private void ApplyAttackOverlay(AttackOverlayMode mode)
+		{
+			if (_overlay == null)
+			{
+				return;
+			}
+
+			// Temporary visual toggle until dedicated melee/magic overlay textures are wired.
+			_overlay.Visible = mode == AttackOverlayMode.Magic;
+
+			if (DebugCombatFeedback && mode != _lastOverlayMode)
+			{
+				GD.Print($"PlayerNode: overlay mode changed {_lastOverlayMode} -> {mode}");
+				_lastOverlayMode = mode;
 			}
 		}
 


### PR DESCRIPTION
### Motivation
- Introduce a flexible weapon combo and attack payload model so weapons can define per-phase melee/magic payloads and shared animations. 
- Provide a runtime flow to queue attack payloads from animation phases and resolve damage, status effects, and target delivery centrally. 
- Wire combo profiles into inventory/weapon loading and player state machine so combos can be executed, buffered, and advanced. 

### Description
- Added new resource types and runtime packets: `AttackPayloadResource`, `ComboPhaseResource`, `WeaponComboResource`, and `AttackPayloadPacket`, plus two combo assets (`rusted_sword_combo.tres`, `iron_longsword_combo.tres`).
- Implemented `AttackAction` state action that handles attack phases, active/buffer windows, input buffering (melee vs magic), animation resolution, payload queuing, and combo advancement.
- Extended `CombatManager` to queue and resolve `AttackPayloadPacket`s, compute damage/crit/mitigation, manage runtime statuses, register delivery/effect handlers (SingleTarget/Cone/Linear and effects like `Knockback`/`Slow`), and provide an API to queue payloads.
- Updated player and UI integration: `Player` gained attack/input state, `PlayerNode` handles attack input and overlay visuals, new state transitions (`AttackPressedTransition`, `AttackCompleteTransition`) and `PlayerStateBuilder` includes the `Attack` state.
- Inventory and data plumbing: CSV schema updated with a `combo_profile_path` column, `MasterRepository`/`GameManager` updated to read it, and `WeaponItem` loads and exposes combo profiles.
- Added `CombatFeedbackBus` for logging and presentation hooks, and improved `CombatEntity` HP/Mana setters to clamp bounds.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6cd832b188326aa299e9c366bdef3)