### PR TITLE
Add weapon combo authoring docs, validator, preview tool, and combat status handling (knockback/slow/stun/root)

### DIFF
--- a/Core/Combat/Docs/weapon_authoring_workflow.md
+++ b/Core/Combat/Docs/weapon_authoring_workflow.md
@@ -1,0 +1,153 @@
+# Weapon Combo Content Authoring Workflow (Phase 5)
+
+This document defines the production workflow for authoring new weapons and their combo payloads in the Godot editor.
+
+## 1) Naming + Schema Conventions
+
+Use these conventions consistently so authored resources are predictable and validation warnings remain actionable.
+
+### Resource file naming
+
+- Weapon combo resource path: `res://Core/Combat/Data/Combos/<weapon_id>_combo.tres`
+- Example: `res://Core/Combat/Data/Combos/iron_longsword_combo.tres`
+
+### Combo phase naming
+
+- `SharedAnimationName` should use the clip family used by player animation libraries.
+- Prefer `Melee1`, `Melee2`, `Melee3`, etc. (or a parallel magic family if needed).
+- Keep phase index progression monotonic with `Phases` array order.
+
+### Payload id conventions
+
+`AttackPayloadResource` is embedded as sub-resources inside the combo `.tres`.
+
+Recommended sub-resource id shape:
+
+- `AttackPayloadResource_<overlay>_<phase>`
+- Examples: `AttackPayloadResource_melee_1`, `AttackPayloadResource_magic_2`
+
+### Delivery shape schema (`DeliveryShapeId`)
+
+Allowed values are defined in `CombatPayloadSchema`:
+
+- `SingleTarget`
+- `Cone`
+- `Linear`
+
+Any other value will trigger validation warnings and may skip expected runtime delivery handlers.
+
+### Effect id schema (`EffectIds`)
+
+Allowed values are defined in `CombatPayloadSchema` and wired by `CombatManager`:
+
+- `Knockback`
+- `Slow`
+- `Stun`
+- `Root`
+
+Any unknown effect id will trigger validation warnings and runtime warnings.
+
+### Runtime effect behavior (current)
+
+- `Slow`: reduces movement speed while status is active.
+- `Root`: blocks voluntary movement while status is active.
+- `Stun`: blocks voluntary movement while status is active and blocks outgoing hits (`CanHit` guard).
+- `Knockback`: applies an impulse burst movement (with short decay). If duration is configured above 0, it can also persist as a status id.
+
+## 2) Validation Behavior (automatic checks)
+
+`ComboProfileValidator` checks all phases/payloads for:
+
+- missing phase references,
+- missing payload refs (both melee + magic null),
+- unknown `DeliveryShapeId`,
+- unknown `EffectIds`.
+
+Validation runs automatically when combo profiles are loaded via `WeaponItem` (`LoadComboProfile`) and logs issues through Godot output.
+
+## 3) Editor Preview Tool
+
+Use `ComboProfilePreviewTool` (`res://Core/Combat/Tools/ComboProfilePreviewTool.cs`) to preview authored phase/payload setup in-editor.
+
+### Quick setup
+
+1. Open or create a utility scene.
+2. Add a `Node`.
+3. Attach script: `res://Core/Combat/Tools/ComboProfilePreviewTool.cs`.
+4. Assign `ComboProfile` to your weapon combo `.tres`.
+5. Set `PreviewPhase` and `PreviewInput`.
+6. Read `PreviewReport` in the Inspector.
+
+`PreviewReport` shows:
+
+- resolved animation name,
+- resolved payload summary for selected input,
+- active/buffer windows,
+- current validation issue list.
+
+You can leave `AutoRefresh` on, or toggle `RefreshNow` for manual refresh.
+
+## 4) Full Step-by-Step: Create a New Weapon in Godot Editor
+
+This is the required end-to-end workflow for adding a production-ready weapon.
+
+1. **Create / import weapon art assets**
+   - Ensure weapon draw/stow textures exist and are imported.
+
+2. **Create combo profile resource**
+   - In FileSystem, create new resource of type `WeaponComboResource`.
+   - Save as `res://Core/Combat/Data/Combos/<weapon_id>_combo.tres`.
+
+3. **Author phases**
+   - Add `ComboPhaseResource` entries to `Phases` in intended combo order.
+   - For each phase set:
+     - `SharedAnimationName`
+     - `PreferFacingSuffix`
+     - `DurationOverrideSeconds` (if needed)
+     - active and buffer windows (`ActiveWindow*`, `BufferWindow*`)
+
+4. **Author payloads per phase**
+   - Set `MeleePayload` and optionally `MagicPayload` on each phase.
+   - For each payload configure:
+     - `OverlayMode` (`Melee` or `Magic`)
+     - `ManaCost` (magic only, usually > 0)
+     - `DeliveryShapeId` (must match schema)
+     - `DamageType`
+     - `ElementType`
+     - `BasePower`
+     - `EffectIds` (must match schema)
+     - `EffectDurationSeconds`
+
+5. **Validate with preview tool**
+   - Open `res://PackedScenes/Tools/ComboProfilePreviewTool.tscn` (or add the tool script in your own utility scene).
+   - Assign your new combo resource.
+   - Check multiple `PreviewPhase` + `PreviewInput` combinations.
+   - Resolve all `Error` and `Warning` lines in `PreviewReport` before integrating.
+
+6. **Create/update weapon inventory item row**
+   - In items data source, add/update the weapon row with:
+     - core metadata (id, name, rarity, etc.),
+     - texture paths (`weapon_*` fields),
+     - `combo_profile_path` -> new combo `.tres` path.
+
+7. **Confirm runtime loading**
+   - Run the game and equip weapon through normal flow.
+   - Confirm no `ComboProfileValidator` errors in output.
+
+8. **Combat sanity pass in-editor/runtime**
+   - Verify all phases advance in order.
+   - Verify melee vs magic input picks expected payload.
+   - Verify effect IDs apply expected combat behavior (`Slow` speed reduction, `Root` movement lock, `Stun` movement+hit lock, `Knockback` impulse).
+
+9. **Polish pass**
+   - Tune `BasePower`, windows, and effect durations.
+   - Re-run preview checks after each tuning pass.
+
+## 5) Definition of Done for Weapon Authoring
+
+A weapon is considered complete when:
+
+- combo profile follows naming/schema conventions,
+- preview tool resolves expected phase/payload outputs,
+- validator logs no errors (and no unresolved warnings),
+- runtime equip + combo chain works with expected effects.

--- a/Core/Combat/Scripts/CombatPayloadSchema.cs
+++ b/Core/Combat/Scripts/CombatPayloadSchema.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Collections.Generic;
+
+namespace ethra.V1
+{
+    /// <summary>
+    /// Shared schema ids used by combo payload authoring + combat runtime.
+    /// Keep these ids stable to avoid breaking authored resources.
+    /// </summary>
+    public static class CombatPayloadSchema
+    {
+        public static readonly IReadOnlyList<string> KnownDeliveryShapeIds = new[]
+        {
+            "SingleTarget",
+            "Cone",
+            "Linear"
+        };
+
+        public static readonly IReadOnlyList<string> KnownEffectIds = new[]
+        {
+            "Knockback",
+            "Slow",
+            "Stun",
+            "Root"
+        };
+
+        public static bool IsKnownDeliveryShape(string shapeId)
+        {
+            if (string.IsNullOrWhiteSpace(shapeId))
+            {
+                return true;
+            }
+
+            return ContainsIgnoreCase(KnownDeliveryShapeIds, shapeId);
+        }
+
+        public static bool IsKnownEffectId(string effectId)
+        {
+            if (string.IsNullOrWhiteSpace(effectId))
+            {
+                return true;
+            }
+
+            return ContainsIgnoreCase(KnownEffectIds, effectId);
+        }
+
+        private static bool ContainsIgnoreCase(IReadOnlyList<string> source, string value)
+        {
+            for (int i = 0; i < source.Count; i++)
+            {
+                if (string.Equals(source[i], value, StringComparison.OrdinalIgnoreCase))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/Core/Combat/Scripts/ComboProfileValidator.cs
+++ b/Core/Combat/Scripts/ComboProfileValidator.cs
@@ -1,0 +1,137 @@
+using System;
+using System.Collections.Generic;
+using Godot;
+
+namespace ethra.V1
+{
+    public enum ComboValidationSeverity
+    {
+        Info,
+        Warning,
+        Error
+    }
+
+    public readonly struct ComboValidationIssue
+    {
+        public ComboValidationSeverity Severity { get; }
+        public string Message { get; }
+
+        public ComboValidationIssue(ComboValidationSeverity severity, string message)
+        {
+            Severity = severity;
+            Message = message ?? string.Empty;
+        }
+    }
+
+    public static class ComboProfileValidator
+    {
+        public static List<ComboValidationIssue> Validate(WeaponComboResource combo, string comboLabel = "ComboProfile")
+        {
+            List<ComboValidationIssue> issues = new();
+
+            if (combo == null)
+            {
+                issues.Add(new ComboValidationIssue(ComboValidationSeverity.Error, $"{comboLabel}: combo profile resource is null."));
+                return issues;
+            }
+
+            if (combo.Phases == null || combo.Phases.Count == 0)
+            {
+                issues.Add(new ComboValidationIssue(ComboValidationSeverity.Error, $"{comboLabel}: no phases configured."));
+                return issues;
+            }
+
+            for (int i = 0; i < combo.Phases.Count; i++)
+            {
+                ComboPhaseResource phase = combo.Phases[i];
+                string prefix = $"{comboLabel} phase {i + 1}";
+
+                if (phase == null)
+                {
+                    issues.Add(new ComboValidationIssue(ComboValidationSeverity.Error, $"{prefix}: phase reference is null."));
+                    continue;
+                }
+
+                if (phase.MeleePayload == null && phase.MagicPayload == null)
+                {
+                    issues.Add(new ComboValidationIssue(ComboValidationSeverity.Error, $"{prefix}: missing payload refs (both melee and magic are null)."));
+                    continue;
+                }
+
+                if (phase.MeleePayload == null)
+                {
+                    issues.Add(new ComboValidationIssue(ComboValidationSeverity.Warning, $"{prefix}: melee payload is null (runtime will fallback to magic payload)."));
+                }
+
+                if (phase.MagicPayload == null)
+                {
+                    issues.Add(new ComboValidationIssue(ComboValidationSeverity.Info, $"{prefix}: magic payload is null (phase is melee-only)."));
+                }
+
+                ValidatePayload(issues, phase.MeleePayload, prefix, "MeleePayload");
+                ValidatePayload(issues, phase.MagicPayload, prefix, "MagicPayload");
+            }
+
+            return issues;
+        }
+
+        public static void EmitToGodotLog(WeaponComboResource combo, string comboLabel)
+        {
+            List<ComboValidationIssue> issues = Validate(combo, comboLabel);
+            foreach (ComboValidationIssue issue in issues)
+            {
+                string msg = $"ComboProfileValidator: {issue.Message}";
+                if (issue.Severity == ComboValidationSeverity.Error)
+                {
+                    GD.PushError(msg);
+                }
+                else if (issue.Severity == ComboValidationSeverity.Warning)
+                {
+                    GD.PushWarning(msg);
+                }
+                else
+                {
+                    GD.Print(msg);
+                }
+            }
+        }
+
+        private static void ValidatePayload(List<ComboValidationIssue> issues, AttackPayloadResource payload, string phasePrefix, string payloadSlot)
+        {
+            if (payload == null)
+            {
+                return;
+            }
+
+            string payloadPrefix = $"{phasePrefix} {payloadSlot}";
+
+            if (string.IsNullOrWhiteSpace(payload.DeliveryShapeId))
+            {
+                issues.Add(new ComboValidationIssue(ComboValidationSeverity.Warning, $"{payloadPrefix}: DeliveryShapeId is empty, runtime defaults to 'SingleTarget'."));
+            }
+            else if (!CombatPayloadSchema.IsKnownDeliveryShape(payload.DeliveryShapeId))
+            {
+                issues.Add(new ComboValidationIssue(ComboValidationSeverity.Warning, $"{payloadPrefix}: unknown DeliveryShapeId '{payload.DeliveryShapeId}'."));
+            }
+
+            if (payload.EffectIds == null)
+            {
+                return;
+            }
+
+            for (int i = 0; i < payload.EffectIds.Count; i++)
+            {
+                string effectId = payload.EffectIds[i]?.Trim();
+                if (string.IsNullOrWhiteSpace(effectId))
+                {
+                    continue;
+                }
+
+                if (!CombatPayloadSchema.IsKnownEffectId(effectId))
+                {
+                    issues.Add(new ComboValidationIssue(ComboValidationSeverity.Warning, $"{payloadPrefix}: unknown effect id '{effectId}'."));
+                }
+            }
+        }
+    }
+}

--- a/Core/Combat/Tools/ComboProfilePreviewTool.cs
+++ b/Core/Combat/Tools/ComboProfilePreviewTool.cs
@@ -1,0 +1,91 @@
+using System.Text;
+using Godot;
+
+namespace ethra.V1
+{
+    [Tool]
+    public partial class ComboProfilePreviewTool : Node
+    {
+        [Export] public WeaponComboResource ComboProfile { get; set; }
+        [Export(PropertyHint.Range, "1,12,1")] public int PreviewPhase { get; set; } = 1;
+        [Export] public AttackInputType PreviewInput { get; set; } = AttackInputType.Melee;
+        [Export] public bool AutoRefresh { get; set; } = true;
+        [Export] public bool RefreshNow { get; set; } = false;
+
+        [Export(PropertyHint.MultilineText)]
+        public string PreviewReport { get; set; } = "Assign ComboProfile and enable AutoRefresh.";
+
+        public override void _Process(double delta)
+        {
+            if (!Engine.IsEditorHint())
+            {
+                return;
+            }
+
+            if (AutoRefresh || RefreshNow)
+            {
+                RefreshNow = false;
+                BuildReport();
+            }
+        }
+
+        private void BuildReport()
+        {
+            StringBuilder sb = new();
+            string label = ComboProfile?.ResourcePath;
+            if (string.IsNullOrWhiteSpace(label))
+            {
+                label = "(embedded resource)";
+            }
+
+            sb.AppendLine($"Combo: {label}");
+            sb.AppendLine($"Preview selection: phase={PreviewPhase}, input={PreviewInput}");
+
+            if (ComboProfile == null)
+            {
+                sb.AppendLine("No combo profile assigned.");
+                PreviewReport = sb.ToString();
+                return;
+            }
+
+            ComboPhaseResource phase = ComboProfile.GetPhaseForStep(PreviewPhase);
+            if (phase == null)
+            {
+                sb.AppendLine("Selected phase did not resolve.");
+            }
+            else
+            {
+                AttackPayloadResource payload = PreviewInput == AttackInputType.Magic
+                    ? (phase.MagicPayload ?? phase.MeleePayload)
+                    : (phase.MeleePayload ?? phase.MagicPayload);
+
+                sb.AppendLine($"Resolved animation: {phase.SharedAnimationName}");
+                sb.AppendLine($"Resolved payload: {DescribePayload(payload)}");
+                sb.AppendLine($"Windows active=[{phase.ActiveWindowStart:0.###},{phase.ActiveWindowEnd:0.###}] buffer=[{phase.BufferWindowStart:0.###},{phase.BufferWindowEnd:0.###}]");
+            }
+
+            var issues = ComboProfileValidator.Validate(ComboProfile, "PreviewCombo");
+            sb.AppendLine($"Validation issues: {issues.Count}");
+            foreach (var issue in issues)
+            {
+                sb.AppendLine($"- [{issue.Severity}] {issue.Message}");
+            }
+
+            PreviewReport = sb.ToString();
+        }
+
+        private static string DescribePayload(AttackPayloadResource payload)
+        {
+            if (payload == null)
+            {
+                return "(null payload)";
+            }
+
+            string effectList = payload.EffectIds == null || payload.EffectIds.Count == 0
+                ? "none"
+                : string.Join(",", payload.EffectIds);
+
+            return $"overlay={payload.OverlayMode}, mana={payload.ManaCost}, shape={payload.DeliveryShapeId}, damage={payload.DamageType}, element={payload.ElementType}, basePower={payload.BasePower:0.###}, effects={effectList}, duration={payload.EffectDurationSeconds:0.###}";
+        }
+    }
+}

--- a/Core/Inventory/Scripts/WeaponItem.cs
+++ b/Core/Inventory/Scripts/WeaponItem.cs
@@ -113,6 +113,8 @@ namespace ethra.V1
                 GD.Print($"WeaponItem: loaded combo profile '{path}' with phaseCount={profile.Phases?.Count ?? 0}.");
             }
 
+            ComboProfileValidator.EmitToGodotLog(profile, $"Weapon '{path}'");
+
             return profile;
         }
     }

--- a/Core/Managers/CombatManager.cs
+++ b/Core/Managers/CombatManager.cs
@@ -24,6 +24,7 @@ namespace ethra.V1
         private readonly Dictionary<string, Func<AttackPayloadPacket, IReadOnlyList<Entity>>> _deliveryHandlers = new(StringComparer.OrdinalIgnoreCase);
         private readonly Dictionary<string, Action<Entity, AttackPayloadPacket, string>> _effectHandlers = new(StringComparer.OrdinalIgnoreCase);
         private readonly Dictionary<Entity, Dictionary<string, StatusRuntime>> _activeStatuses = new();
+        private readonly Dictionary<Entity, Vector2> _knockbackVelocities = new();
         private readonly RandomNumberGenerator _rng = new();
 
         public string SaveKey => _saveKey;
@@ -84,6 +85,11 @@ namespace ethra.V1
         public bool CanHit(Entity attacker, Entity target, string abilityId)
         {
             if (attacker == null || target == null)
+            {
+                return false;
+            }
+
+            if (HasStatus(attacker, "Stun"))
             {
                 return false;
             }
@@ -196,6 +202,46 @@ namespace ethra.V1
             {
                 _activeStatuses.Remove(target);
             }
+
+            if (string.Equals(statusId, "Knockback", StringComparison.OrdinalIgnoreCase))
+            {
+                _knockbackVelocities.Remove(target);
+            }
+        }
+
+        public bool HasStatus(Entity target, string statusId)
+        {
+            if (target == null || string.IsNullOrWhiteSpace(statusId))
+            {
+                return false;
+            }
+
+            return _activeStatuses.TryGetValue(target, out Dictionary<string, StatusRuntime> statusMap)
+                && statusMap.TryGetValue(statusId, out StatusRuntime runtime)
+                && runtime.Stacks > 0;
+        }
+
+        public Vector2 ResolveMovementVelocity(Entity target, Vector2 desiredVelocity)
+        {
+            if (target == null)
+            {
+                return desiredVelocity;
+            }
+
+            Vector2 finalVelocity = desiredVelocity;
+            if (HasStatus(target, "Stun") || HasStatus(target, "Root"))
+            {
+                finalVelocity = Vector2.Zero;
+            }
+
+            finalVelocity *= GetSlowMultiplier(target);
+
+            if (_knockbackVelocities.TryGetValue(target, out Vector2 knockback))
+            {
+                finalVelocity += knockback;
+            }
+
+            return finalVelocity;
         }
 
         public void Resolve()
@@ -302,16 +348,23 @@ namespace ethra.V1
             _deliveryHandlers["Linear"] = packet => GetEnemyTargets();
 
             _effectHandlers["Knockback"] = (target, packet, effectId) =>
-                ApplyStatus(target, "Knockback", 1, packet.Payload.EffectDurationSeconds, packet.Source);
+            {
+                ApplyKnockbackImpulse(target, packet);
+
+                if (packet.Payload.EffectDurationSeconds > 0f)
+                {
+                    ApplyStatus(target, effectId, 1, packet.Payload.EffectDurationSeconds, packet.Source);
+                }
+            };
 
             _effectHandlers["Slow"] = (target, packet, effectId) =>
-                ApplyStatus(target, "Slow", 1, packet.Payload.EffectDurationSeconds, packet.Source);
+                ApplyStatus(target, effectId, 1, packet.Payload.EffectDurationSeconds, packet.Source);
 
             _effectHandlers["Stun"] = (target, packet, effectId) =>
-                ApplyStatus(target, "Stun", 1, packet.Payload.EffectDurationSeconds, packet.Source);
+                ApplyStatus(target, effectId, 1, packet.Payload.EffectDurationSeconds, packet.Source);
 
             _effectHandlers["Root"] = (target, packet, effectId) =>
-                ApplyStatus(target, "Root", 1, packet.Payload.EffectDurationSeconds, packet.Source);
+                ApplyStatus(target, effectId, 1, packet.Payload.EffectDurationSeconds, packet.Source);
         }
 
         private List<Entity> GetEnemyTargets()
@@ -392,6 +445,7 @@ namespace ethra.V1
         {
             if (delta <= 0f || _activeStatuses.Count == 0)
             {
+                TickKnockback(delta);
                 return;
             }
 
@@ -417,6 +471,69 @@ namespace ethra.V1
             foreach ((Entity target, string status) in expired)
             {
                 RemoveStatus(target, status, int.MaxValue);
+            }
+
+            TickKnockback(delta);
+        }
+
+        private float GetSlowMultiplier(Entity target)
+        {
+            if (!_activeStatuses.TryGetValue(target, out Dictionary<string, StatusRuntime> statusMap))
+            {
+                return 1f;
+            }
+
+            if (!statusMap.TryGetValue("Slow", out StatusRuntime runtime) || runtime.Stacks <= 0)
+            {
+                return 1f;
+            }
+
+            float multiplier = 1f - 0.35f * runtime.Stacks;
+            return Mathf.Clamp(multiplier, 0.2f, 1f);
+        }
+
+        private void ApplyKnockbackImpulse(Entity target, AttackPayloadPacket packet)
+        {
+            if (target == null)
+            {
+                return;
+            }
+
+            Vector2 direction = packet.ForwardDirection;
+            if (direction.LengthSquared() <= 0.0001f)
+            {
+                direction = Vector2.Right;
+            }
+
+            direction = direction.Normalized();
+            const float impulseSpeed = 220f;
+            _knockbackVelocities[target] = direction * impulseSpeed;
+        }
+
+        private void TickKnockback(float delta)
+        {
+            if (delta <= 0f || _knockbackVelocities.Count == 0)
+            {
+                return;
+            }
+
+            List<Entity> completed = new();
+            foreach ((Entity target, Vector2 velocity) in _knockbackVelocities)
+            {
+                Vector2 damped = velocity.MoveToward(Vector2.Zero, 900f * delta);
+                if (damped.LengthSquared() <= 0.01f)
+                {
+                    completed.Add(target);
+                }
+                else
+                {
+                    _knockbackVelocities[target] = damped;
+                }
+            }
+
+            foreach (Entity entity in completed)
+            {
+                _knockbackVelocities.Remove(entity);
             }
         }
 

--- a/Core/Nodes/Entity/PlayerNode.cs
+++ b/Core/Nodes/Entity/PlayerNode.cs
@@ -77,7 +77,13 @@ namespace ethra.V1
 			_player.Tick(dt);
 			ApplyAttackOverlay(_player.CurrentAttackOverlay);
 
-			Velocity = _player.DesiredVelocity;
+			Vector2 desiredVelocity = _player.DesiredVelocity;
+			if (_gm?.Combat != null)
+			{
+				desiredVelocity = _gm.Combat.ResolveMovementVelocity(_player, desiredVelocity);
+			}
+
+			Velocity = desiredVelocity;
 
 			MoveAndSlide();
 

--- a/PackedScenes/Tools/ComboProfilePreviewTool.tscn
+++ b/PackedScenes/Tools/ComboProfilePreviewTool.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://Core/Combat/Tools/ComboProfilePreviewTool.cs" id="1"]
+
+[node name="ComboProfilePreviewTool" type="Node"]
+script = ExtResource("1")


### PR DESCRIPTION
### Motivation

- Provide a clear production workflow and in-editor tooling for authoring weapon combo profiles so resources are consistent and easier to validate.
- Centralize known payload ids to avoid hard-to-detect authoring/runtime mismatches.
- Implement runtime handling for common combat effects (Knockback, Slow, Stun, Root) and integrate validation into load flow.

### Description

- Add documentation `Core/Combat/Docs/weapon_authoring_workflow.md` that details naming/schema conventions, authoring steps, validation, preview usage, and definition-of-done.
- Add `CombatPayloadSchema` with stable lists of known `DeliveryShapeIds` and `EffectIds` and helper lookup methods.
- Add `ComboProfileValidator` that performs phase/payload validation and can emit issues to the Godot output (Info/Warning/Error).
- Add `ComboProfilePreviewTool` (script and `.tscn`) to preview resolved phase/payload data and show validation reports in the editor.
- Wire validator into weapon loading by calling `ComboProfileValidator.EmitToGodotLog` in `WeaponItem.LoadComboProfile` when combo profiles are loaded.
- Extend `CombatManager` with status runtime bookkeeping and behavior for `Knockback`, `Slow`, `Stun`, and `Root`, including `_knockbackVelocities`, `ApplyKnockbackImpulse`, `TickKnockback`, `HasStatus`, `ResolveMovementVelocity`, and `GetSlowMultiplier`, and make `Stun` prevent outgoing hits in `CanHit`.
- Update default effect handlers to apply knockback impulse and to apply statuses using schema ids, and adjust status removal to clear knockback velocities when `Knockback` expires.
- Update `PlayerNode` movement integration to call `CombatManager.ResolveMovementVelocity` so active statuses affect player movement.

### Testing

- No automated tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e82d3064cc832694ffe7a6514ab724)