### PR TITLE
Initialize entity stats and new-game setup (starter weapon, enemy registration)

### DIFF
--- a/Core/Entity/Scripts/CombatEntity.cs
+++ b/Core/Entity/Scripts/CombatEntity.cs
@@ -76,6 +76,29 @@ namespace ethra.V1
         {
             _combat = combat;
         }
+
+        public void InitializeStats(
+            int maxHp,
+            int maxMana,
+            int strength,
+            int dexterity,
+            int intelligence,
+            int spirit,
+            int vitality,
+            int luck)
+        {
+            _maxHP = maxHp;
+            _curHP = maxHp;
+            _maxMana = maxMana;
+            _curMana = maxMana;
+            _str = strength;
+            _dex = dexterity;
+            _int = intelligence;
+            _spi = spirit;
+            _vit = vitality;
+            _luk = luck;
+        }
+
         public void ApplyStatus(Entity target, string statusId, int stacks = 1, float? durationSeconds = null, Entity source = null)
         {
             throw new System.NotImplementedException();

--- a/Core/Entity/Scripts/Entity.cs
+++ b/Core/Entity/Scripts/Entity.cs
@@ -24,6 +24,11 @@ namespace ethra.V1
 
         public FacingDirection Facing {get; set;}
 
+        public void SetName(string name)
+        {
+            _name = name;
+        }
+
 
         public Vector2 DesiredVelocity { get{return _desiredVelocity;} set{_desiredVelocity = value;} } 
         public string RequestedAnimation { get; set; } = "Idle_Down";

--- a/Core/Managers/EntityManager.cs
+++ b/Core/Managers/EntityManager.cs
@@ -54,7 +54,16 @@ namespace ethra.V1
 
         public void SpawnEnemy(Enemy enemy)
         {
-            throw new NotImplementedException();
+            if (enemy == null)
+            {
+                return;
+            }
+
+            registeredEnemies ??= new List<Enemy>();
+            if (!registeredEnemies.Contains(enemy))
+            {
+                registeredEnemies.Add(enemy);
+            }
         }
 
         public void SpawnNPC(NPC npc)
@@ -75,8 +84,21 @@ namespace ethra.V1
        
         public Enemy CreateEnemy(string name,int level, IEntityManager entity, ICombat combat, IStateMachine fsm)
         {
+            registeredEnemies ??= new List<Enemy>();
+
             Enemy enemy = new Enemy(entity, combat, fsm);
-            
+            enemy.SetName(string.IsNullOrWhiteSpace(name) ? "Enemy" : name);
+            enemy.InitializeStats(
+                maxHp: 50,
+                maxMana: 0,
+                strength: 5,
+                dexterity: 5,
+                intelligence: 0,
+                spirit: 0,
+                vitality: 5,
+                luck: 0);
+
+            registeredEnemies.Add(enemy);
             return enemy;
         }
 

--- a/Core/Managers/GameManager.cs
+++ b/Core/Managers/GameManager.cs
@@ -43,6 +43,7 @@ namespace ethra.V1
 		// ==== Game Manager specific fields =====//
 
 	private int _saveslot;
+	private const int StarterWeaponItemId = 2001;
 
 	private List<IResolveable> _resolveList;
 	public int ResolveOrder => _resolveOrder;
@@ -288,20 +289,80 @@ namespace ethra.V1
 	}
 
 	public Player CreatePlayerModel()
-{
-	// Create the FSM here so the flow is explicit
-	IStateMachine fsm = new StateMachine();
+	{
+		// Create the FSM here so the flow is explicit
+		IStateMachine fsm = new StateMachine();
 
-	// Delegate actual construction to EntityManager
-	Player player = _entity.CreatePlayer(
-		combat: _combat,
-		inventory: _inventory,
-		fsm: fsm
-	);
-			
+		// Delegate actual construction to EntityManager
+		Player player = _entity.CreatePlayer(
+			combat: _combat,
+			inventory: _inventory,
+			fsm: fsm
+		);
 
-	return player;
-}
+		InitializeNewGamePlayer(player);
+		EquipStarterWeapon(player);
+		EnsureStarterEnemyRegistered();
+
+		return player;
+	}
+
+	private void InitializeNewGamePlayer(Player player)
+	{
+		if (player == null)
+		{
+			return;
+		}
+
+		player.SetName("Player");
+		player.InitializeStats(
+			maxHp: ToStat(hpBase),
+			maxMana: ToStat(mpBase),
+			strength: ToStat(strBase),
+			dexterity: ToStat(dexBase),
+			intelligence: ToStat(intBase),
+			spirit: ToStat(spiBase),
+			vitality: ToStat(vitBase),
+			luck: ToStat(lukBase));
+	}
+
+	private void EquipStarterWeapon(Player player)
+	{
+		if (player == null)
+		{
+			return;
+		}
+
+		if (_db.GetItemFromRepo(StarterWeaponItemId) is not InventoryItem item)
+		{
+			GD.PushWarning($"Starter weapon id {StarterWeaponItemId} was not found in the item repository.");
+			return;
+		}
+
+		item.SetOwner(player);
+		_inventory.AddItem(StarterWeaponItemId);
+		_inventory.UseItem(StarterWeaponItemId);
+	}
+
+	private void EnsureStarterEnemyRegistered()
+	{
+		if (_entity.registeredEnemies.Count > 0)
+		{
+			return;
+		}
+
+		_entity.CreateEnemy(
+			name: "Training Dummy",
+			level: 1,
+			entity: _entity,
+			combat: _combat,
+			fsm: new StateMachine());
+	}
+
+	private static int ToStat(double value)
+	{
+		return Math.Max(0, Mathf.RoundToInt((float)value));
+	}
 
 	public void SpawnPlayerAfterSceneLoad()
 	{


### PR DESCRIPTION
### Motivation
- Provide explicit stat initialization for combat-capable entities to avoid ad-hoc field setting. 
- Ensure newly created player models are fully initialized at new-game start including default stats and equipment. 
- Make enemy registration and spawning more robust by handling null values and keeping the registered enemies registry in sync.

### Description
- Added `InitializeStats` to `CombatEntity` to set HP, Mana and core stats in one call. 
- Added `SetName` to `Entity` to allow naming entities after construction. 
- Made `EntityManager.SpawnEnemy` null-safe and ensure the enemy is added to `registeredEnemies`, and updated `CreateEnemy` to set a default name and call `InitializeStats` before registering the enemy. 
- Extended `GameManager` new-game flow by updating `CreatePlayerModel` to call `InitializeNewGamePlayer`, `EquipStarterWeapon`, and `EnsureStarterEnemyRegistered`, introduced `StarterWeaponItemId`, and added helper methods `InitializeNewGamePlayer`, `EquipStarterWeapon`, `EnsureStarterEnemyRegistered`, and `ToStat` to centralize initialization and starter setup logic.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2019cb12fc8326a8d347ec20b07d86)